### PR TITLE
Store deployment logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.env
 main
+trh-backend
 path/**
 storage/**
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -777,6 +777,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/stacks/thanos/{id}/deployments/{deploymentId}/logs": {
+            "get": {
+                "description": "Get logs for a deployment (paginated)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Thanos Stack"
+                ],
+                "summary": "Get Deployment Logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thanos Stack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Deployment ID",
+                        "name": "deploymentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 200,
+                        "description": "Max logs to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Return logs after this log id (exclusive)",
+                        "name": "afterId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/entities.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/stacks/thanos/{id}/deployments/{deploymentId}/status": {
             "get": {
                 "description": "Get Stack Deployment Status",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1143,6 +1143,51 @@ const docTemplate = `{
                 }
             }
         },
+        "/stacks/thanos/{id}/logs": {
+            "get": {
+                "description": "Get logs across all deployments for a stack (paginated)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Thanos Stack"
+                ],
+                "summary": "Get Stack Logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thanos Stack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 200,
+                        "description": "Max logs to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Return logs after this log id (exclusive)",
+                        "name": "afterId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/entities.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/stacks/thanos/{id}/register-candidates": {
             "post": {
                 "description": "Register Candidates",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1137,6 +1137,51 @@
                 }
             }
         },
+        "/stacks/thanos/{id}/logs": {
+            "get": {
+                "description": "Get logs across all deployments for a stack (paginated)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Thanos Stack"
+                ],
+                "summary": "Get Stack Logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thanos Stack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 200,
+                        "description": "Max logs to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Return logs after this log id (exclusive)",
+                        "name": "afterId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/entities.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/stacks/thanos/{id}/register-candidates": {
             "post": {
                 "description": "Register Candidates",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -771,6 +771,58 @@
                 }
             }
         },
+        "/stacks/thanos/{id}/deployments/{deploymentId}/logs": {
+            "get": {
+                "description": "Get logs for a deployment (paginated)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Thanos Stack"
+                ],
+                "summary": "Get Deployment Logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thanos Stack ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Deployment ID",
+                        "name": "deploymentId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 200,
+                        "description": "Max logs to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Return logs after this log id (exclusive)",
+                        "name": "afterId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/entities.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/stacks/thanos/{id}/deployments/{deploymentId}/status": {
             "get": {
                 "description": "Get Stack Deployment Status",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -749,6 +749,41 @@ paths:
       summary: Get Stack Deployment
       tags:
       - Thanos Stack
+  /stacks/thanos/{id}/deployments/{deploymentId}/logs:
+    get:
+      consumes:
+      - application/json
+      description: Get logs for a deployment (paginated)
+      parameters:
+      - description: Thanos Stack ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Deployment ID
+        in: path
+        name: deploymentId
+        required: true
+        type: string
+      - default: 200
+        description: Max logs to return
+        in: query
+        name: limit
+        type: integer
+      - description: Return logs after this log id (exclusive)
+        in: query
+        name: afterId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entities.Response'
+      summary: Get Deployment Logs
+      tags:
+      - Thanos Stack
   /stacks/thanos/{id}/deployments/{deploymentId}/status:
     get:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -992,6 +992,36 @@ paths:
       summary: Install Monitoring
       tags:
       - Thanos Stack
+  /stacks/thanos/{id}/logs:
+    get:
+      consumes:
+      - application/json
+      description: Get logs across all deployments for a stack (paginated)
+      parameters:
+      - description: Thanos Stack ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - default: 200
+        description: Max logs to return
+        in: query
+        name: limit
+        type: integer
+      - description: Return logs after this log id (exclusive)
+        in: query
+        name: afterId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entities.Response'
+      summary: Get Stack Logs
+      tags:
+      - Thanos Stack
   /stacks/thanos/{id}/register-candidates:
     post:
       consumes:

--- a/pkg/api/handlers/thanos/base.go
+++ b/pkg/api/handlers/thanos/base.go
@@ -15,10 +15,11 @@ func NewThanosHandler(server *servers.Server) *ThanosDeploymentHandler {
 	deploymentRepo := postgresRepositories.NewDeploymentRepository(server.PostgresDB)
 	stackRepo := postgresRepositories.NewStackRepository(server.PostgresDB)
 	integrationRepo := postgresRepositories.NewIntegrationRepository(server.PostgresDB)
+	logRepo := postgresRepositories.NewLogRepository(server.PostgresDB)
 
 	taskManager := taskmanager.NewTaskManager(5, 20)
 
 	return &ThanosDeploymentHandler{
-		ThanosDeploymentService: thanos.NewThanosService(deploymentRepo, stackRepo, integrationRepo, taskManager),
+		ThanosDeploymentService: thanos.NewThanosService(deploymentRepo, stackRepo, integrationRepo, taskManager, logRepo),
 	}
 }

--- a/pkg/api/handlers/thanos/deployment.go
+++ b/pkg/api/handlers/thanos/deployment.go
@@ -2,6 +2,7 @@ package thanos
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/tokamak-network/trh-backend/internal/logger"
 	"github.com/tokamak-network/trh-backend/internal/utils"
@@ -151,4 +152,77 @@ func (h *ThanosDeploymentHandler) Terminate(c *gin.Context) {
 		logger.Error("failed to terminate thanos stack", zap.Error(err), zap.String("id", id))
 	}
 	c.JSON(int(response.Status), response)
+}
+
+// @Summary     Get Deployment Logs
+// @Description Get logs for a deployment (paginated)
+// @Tags        Thanos Stack
+// @Accept      json
+// @Produce     json
+// @Param       id path string true "Thanos Stack ID"
+// @Param       deploymentId path string true "Deployment ID"
+// @Param       limit query int false "Max logs to return" default(200)
+// @Param       afterId query string false "Return logs after this log id (exclusive)"
+// @Success     200 {object} entities.Response
+// @Router      /stacks/thanos/{id}/deployments/{deploymentId}/logs [get]
+func (h *ThanosDeploymentHandler) GetDeploymentLogs(c *gin.Context) {
+	id := c.Param("id")
+	deploymentId := c.Param("deploymentId")
+
+	if id == "" || deploymentId == "" {
+		c.JSON(http.StatusBadRequest, &entities.Response{Status: http.StatusBadRequest, Message: "id and deploymentId are required"})
+		return
+	}
+
+	limit := 200
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 1000 {
+			limit = parsed
+		}
+	}
+	var afterIDPtr *string
+	if after := c.Query("afterId"); after != "" {
+		afterIDPtr = &after
+	}
+
+	resp, err := h.ThanosDeploymentService.GetDeploymentLogs(uuid.MustParse(id), uuid.MustParse(deploymentId), limit, afterIDPtr)
+	if err != nil {
+		logger.Error("failed to get deployment logs", zap.Error(err))
+	}
+	c.JSON(int(resp.Status), resp)
+}
+
+// @Summary     Get Stack Logs
+// @Description Get logs across all deployments for a stack (paginated)
+// @Tags        Thanos Stack
+// @Accept      json
+// @Produce     json
+// @Param       id path string true "Thanos Stack ID"
+// @Param       limit query int false "Max logs to return" default(200)
+// @Param       afterId query string false "Return logs after this log id (exclusive)"
+// @Success     200 {object} entities.Response
+// @Router      /stacks/thanos/{id}/logs [get]
+func (h *ThanosDeploymentHandler) GetStackLogs(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, &entities.Response{Status: http.StatusBadRequest, Message: "id is required"})
+		return
+	}
+
+	limit := 200
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 1000 {
+			limit = parsed
+		}
+	}
+	var afterIDPtr *string
+	if after := c.Query("afterId"); after != "" {
+		afterIDPtr = &after
+	}
+
+	resp, err := h.ThanosDeploymentService.GetStackLogs(uuid.MustParse(id), limit, afterIDPtr)
+	if err != nil {
+		logger.Error("failed to get stack logs", zap.Error(err))
+	}
+	c.JSON(int(resp.Status), resp)
 }

--- a/pkg/api/routes/route.go
+++ b/pkg/api/routes/route.go
@@ -147,5 +147,7 @@ func setupThanosRoutes(router *gin.RouterGroup, server *servers.Server, jwtMiddl
 		authenticatedRoutes.GET("/:id/integrations/:integrationId", handler.GetIntegrationById)
 		authenticatedRoutes.GET("/:id/deployments/:deploymentId", handler.GetStackDeployment)
 		authenticatedRoutes.GET("/:id/deployments/:deploymentId/status", handler.GetStackDeploymentStatus)
+		authenticatedRoutes.GET("/:id/deployments/:deploymentId/logs", handler.GetDeploymentLogs)
+		authenticatedRoutes.GET("/:id/logs", handler.GetStackLogs)
 	}
 }

--- a/pkg/domain/entities/deployment.go
+++ b/pkg/domain/entities/deployment.go
@@ -2,20 +2,23 @@ package entities
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 type DeploymentEntity struct {
-	ID      uuid.UUID        `json:"id"`
-	StackID *uuid.UUID       `json:"stack_id,omitempty"`
-	Step    string           `json:"step"`
-	Status  DeploymentStatus `json:"status"`
-	LogPath string           `json:"log_path"`
-	Config  json.RawMessage  `json:"config"`
+	ID         uuid.UUID           `json:"id"`
+	StackID    *uuid.UUID          `json:"stack_id,omitempty"`
+	Step       string              `json:"step"`
+	Status     DeploymentRunStatus `json:"status"`
+	LogPath    string              `json:"log_path"`
+	Config     json.RawMessage     `json:"config"`
+	StartedAt  *time.Time          `json:"started_at,omitempty"`
+	FinishedAt *time.Time          `json:"finished_at,omitempty"`
 }
 
 type DeploymentStatusWithID struct {
 	DeploymentID uuid.UUID
-	Status       DeploymentStatus
+	Status       DeploymentRunStatus
 }

--- a/pkg/domain/entities/deployment.go
+++ b/pkg/domain/entities/deployment.go
@@ -9,7 +9,7 @@ import (
 type DeploymentEntity struct {
 	ID      uuid.UUID        `json:"id"`
 	StackID *uuid.UUID       `json:"stack_id,omitempty"`
-	Step    int              `json:"step"`
+	Step    string           `json:"step"`
 	Status  DeploymentStatus `json:"status"`
 	LogPath string           `json:"log_path"`
 	Config  json.RawMessage  `json:"config"`

--- a/pkg/domain/entities/enums.go
+++ b/pkg/domain/entities/enums.go
@@ -37,6 +37,16 @@ const (
 	DeploymentStatusUnknown     DeploymentStatus = "Unknown"
 )
 
+// DeploymentRunStatus is used for deployment steps (not integrations)
+type DeploymentRunStatus string
+
+const (
+	DeploymentRunStatusNotStarted DeploymentRunStatus = "Not Started"
+	DeploymentRunStatusInProgress DeploymentRunStatus = "InProgress"
+	DeploymentRunStatusFailed     DeploymentRunStatus = "Failed"
+	DeploymentRunStatusSuccess    DeploymentRunStatus = "Success"
+)
+
 type UserRole string
 
 const (

--- a/pkg/domain/entities/log.go
+++ b/pkg/domain/entities/log.go
@@ -1,0 +1,16 @@
+package entities
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LogEntity represents a single deployment log entry
+type LogEntity struct {
+	ID           uuid.UUID  `json:"id"`
+	StackID      *uuid.UUID `json:"stack_id,omitempty"`
+	DeploymentID *uuid.UUID `json:"deployment_id,omitempty"`
+	Message      string     `json:"message"`
+	CreatedAt    time.Time  `json:"created_at"`
+}

--- a/pkg/infrastructure/postgres/connection/connection.go
+++ b/pkg/infrastructure/postgres/connection/connection.go
@@ -47,7 +47,7 @@ func Init(
 	sqlDB.SetMaxOpenConns(100)          // Maximum number of open connections
 	sqlDB.SetConnMaxLifetime(time.Hour) // Maximum lifetime of a connection
 
-	err = db.AutoMigrate(&schemas.Stack{}, &schemas.Deployment{}, &schemas.Integration{}, &schemas.User{}, &schemas.AWSCredentials{})
+	err = db.AutoMigrate(&schemas.Stack{}, &schemas.Deployment{}, &schemas.Integration{}, &schemas.User{}, &schemas.AWSCredentials{}, &schemas.Log{})
 	if err != nil {
 		logger.Errorf("Failed to auto migrate DB schemas", "err", err.Error())
 		return nil, err
@@ -107,6 +107,17 @@ func createIndexes(db *gorm.DB) error {
 
 	// AWS Credentials indexes
 	if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_aws_credentials_name ON aws_credentials(name)").Error; err != nil {
+		return err
+	}
+
+	// Logs indexes
+	if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_logs_stack_id ON logs(stack_id)").Error; err != nil {
+		return err
+	}
+	if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_logs_deployment_id ON logs(deployment_id)").Error; err != nil {
+		return err
+	}
+	if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_logs_created_at ON logs(created_at)").Error; err != nil {
 		return err
 	}
 

--- a/pkg/infrastructure/postgres/repositories/deployment.go
+++ b/pkg/infrastructure/postgres/repositories/deployment.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
 	"github.com/tokamak-network/trh-backend/pkg/infrastructure/postgres/schemas"
@@ -24,14 +25,24 @@ func (r *DeploymentRepository) CreateDeployment(deployment *entities.DeploymentE
 
 func (r *DeploymentRepository) UpdateDeploymentStatus(
 	id string,
-	status entities.DeploymentStatus,
+	status entities.DeploymentRunStatus,
 ) error {
-	return r.db.Model(&schemas.Deployment{}).Where("id = ?", id).Update("status", status).Error
+	updates := map[string]interface{}{
+		"status": status,
+	}
+	now := time.Now().UTC()
+	if status == entities.DeploymentRunStatusInProgress {
+		updates["started_at"] = &now
+	}
+	if status == entities.DeploymentRunStatusFailed || status == entities.DeploymentRunStatusSuccess {
+		updates["finished_at"] = &now
+	}
+	return r.db.Model(&schemas.Deployment{}).Where("id = ?", id).Updates(updates).Error
 }
 
 func (r *DeploymentRepository) UpdateStatusesByStackId(
 	stackID string,
-	status entities.DeploymentStatus,
+	status entities.DeploymentRunStatus,
 ) error {
 	return r.db.Model(&schemas.Deployment{}).Where("stack_id = ?", stackID).Update("status", status).Error
 }
@@ -46,12 +57,14 @@ func (r *DeploymentRepository) GetDeploymentByID(id string) (*entities.Deploymen
 		return nil, err
 	}
 	return &entities.DeploymentEntity{
-		ID:      deployment.ID,
-		StackID: deployment.StackID,
-		Step:    deployment.Step,
-		Status:  deployment.Status,
-		LogPath: deployment.LogPath,
-		Config:  json.RawMessage(deployment.Config),
+		ID:         deployment.ID,
+		StackID:    deployment.StackID,
+		Step:       deployment.Step,
+		Status:     deployment.Status,
+		LogPath:    deployment.LogPath,
+		Config:     json.RawMessage(deployment.Config),
+		StartedAt:  deployment.StartedAt,
+		FinishedAt: deployment.FinishedAt,
 	}, nil
 }
 
@@ -68,32 +81,36 @@ func (r *DeploymentRepository) GetDeploymentsByStackID(
 	deploymentsEntities := make([]*entities.DeploymentEntity, len(deployments))
 	for i, deployment := range deployments {
 		deploymentsEntities[i] = &entities.DeploymentEntity{
-			ID:      deployment.ID,
-			StackID: deployment.StackID,
-			Step:    deployment.Step,
-			Status:  deployment.Status,
-			LogPath: deployment.LogPath,
-			Config:  json.RawMessage(deployment.Config),
+			ID:         deployment.ID,
+			StackID:    deployment.StackID,
+			Step:       deployment.Step,
+			Status:     deployment.Status,
+			LogPath:    deployment.LogPath,
+			Config:     json.RawMessage(deployment.Config),
+			StartedAt:  deployment.StartedAt,
+			FinishedAt: deployment.FinishedAt,
 		}
 	}
 	return deploymentsEntities, nil
 }
 
-func (r *DeploymentRepository) GetDeploymentStatus(id string) (entities.DeploymentStatus, error) {
+func (r *DeploymentRepository) GetDeploymentStatus(id string) (entities.DeploymentRunStatus, error) {
 	var deployment schemas.Deployment
 	if err := r.db.Where("id = ?", id).First(&deployment).Error; err != nil {
-		return entities.DeploymentStatusUnknown, err
+		return entities.DeploymentRunStatus(""), err
 	}
 	return deployment.Status, nil
 }
 
 func ToDeploymentSchema(d *entities.DeploymentEntity) *schemas.Deployment {
 	return &schemas.Deployment{
-		ID:      d.ID,
-		StackID: d.StackID,
-		Step:    d.Step,
-		Status:  d.Status,
-		LogPath: d.LogPath,
-		Config:  datatypes.JSON(d.Config),
+		ID:         d.ID,
+		StackID:    d.StackID,
+		Step:       d.Step,
+		Status:     d.Status,
+		LogPath:    d.LogPath,
+		Config:     datatypes.JSON(d.Config),
+		StartedAt:  d.StartedAt,
+		FinishedAt: d.FinishedAt,
 	}
 }

--- a/pkg/infrastructure/postgres/repositories/log.go
+++ b/pkg/infrastructure/postgres/repositories/log.go
@@ -1,0 +1,118 @@
+package repositories
+
+import (
+	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
+	"github.com/tokamak-network/trh-backend/pkg/infrastructure/postgres/schemas"
+	"gorm.io/gorm"
+)
+
+type LogRepository struct {
+	db *gorm.DB
+}
+
+func NewLogRepository(db *gorm.DB) *LogRepository {
+	return &LogRepository{db: db}
+}
+
+func (r *LogRepository) CreateLog(log *entities.LogEntity) error {
+	model := &schemas.Log{
+		StackID:      log.StackID,
+		DeploymentID: log.DeploymentID,
+		Message:      log.Message,
+	}
+	return r.db.Create(model).Error
+}
+
+func (r *LogRepository) GetLogsByDeploymentID(deploymentId string, limit int, afterID *string) ([]*entities.LogEntity, error) {
+	var models []schemas.Log
+
+	// If afterID provided, use it as a cursor based on (created_at, id)
+	if afterID != nil && *afterID != "" {
+		// fetch cursor
+		var cursor schemas.Log
+		if err := r.db.First(&cursor, "id = ?", *afterID).Error; err != nil {
+			if err != gorm.ErrRecordNotFound {
+				return nil, err
+			}
+			// if not found, treat like no cursor
+			afterID = nil
+		} else {
+			// Query logs strictly after the cursor
+			if err := r.db.Where("deployment_id = ? AND (created_at > ?) OR (deployment_id = ? AND created_at = ? AND id > ?)",
+				deploymentId, cursor.CreatedAt,
+				deploymentId, cursor.CreatedAt, cursor.ID,
+			).Order("created_at ASC, id ASC").Limit(limit).Find(&models).Error; err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if afterID == nil || *afterID == "" {
+		// No cursor: return the last N rows by created_at DESC then reverse to ascending
+		if err := r.db.Where("deployment_id = ?", deploymentId).
+			Order("created_at DESC, id DESC").Limit(limit).Find(&models).Error; err != nil {
+			return nil, err
+		}
+		// reverse slice to ascending order
+		for i, j := 0, len(models)-1; i < j; i, j = i+1, j-1 {
+			models[i], models[j] = models[j], models[i]
+		}
+	}
+
+	logs := make([]*entities.LogEntity, 0, len(models))
+	for i := range models {
+		m := models[i]
+		logs = append(logs, &entities.LogEntity{
+			ID:           m.ID,
+			StackID:      m.StackID,
+			DeploymentID: m.DeploymentID,
+			Message:      m.Message,
+			CreatedAt:    m.CreatedAt,
+		})
+	}
+	return logs, nil
+}
+
+func (r *LogRepository) GetLogsByStackID(stackId string, limit int, afterID *string) ([]*entities.LogEntity, error) {
+	var models []schemas.Log
+
+	if afterID != nil && *afterID != "" {
+		var cursor schemas.Log
+		if err := r.db.First(&cursor, "id = ?", *afterID).Error; err != nil {
+			if err != gorm.ErrRecordNotFound {
+				return nil, err
+			}
+			afterID = nil
+		} else {
+			if err := r.db.Where("stack_id = ? AND (created_at > ?) OR (stack_id = ? AND created_at = ? AND id > ?)",
+				stackId, cursor.CreatedAt,
+				stackId, cursor.CreatedAt, cursor.ID,
+			).Order("created_at ASC, id ASC").Limit(limit).Find(&models).Error; err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if afterID == nil || *afterID == "" {
+		if err := r.db.Where("stack_id = ?", stackId).
+			Order("created_at DESC, id DESC").Limit(limit).Find(&models).Error; err != nil {
+			return nil, err
+		}
+		for i, j := 0, len(models)-1; i < j; i, j = i+1, j-1 {
+			models[i], models[j] = models[j], models[i]
+		}
+	}
+
+	logs := make([]*entities.LogEntity, 0, len(models))
+	for i := range models {
+		m := models[i]
+		logs = append(logs, &entities.LogEntity{
+			ID:           m.ID,
+			StackID:      m.StackID,
+			DeploymentID: m.DeploymentID,
+			Message:      m.Message,
+			CreatedAt:    m.CreatedAt,
+		})
+	}
+	return logs, nil
+}

--- a/pkg/infrastructure/postgres/schemas/deployment.go
+++ b/pkg/infrastructure/postgres/schemas/deployment.go
@@ -10,16 +10,18 @@ import (
 )
 
 type Deployment struct {
-	ID        uuid.UUID                 `gorm:"type:uuid;primaryKey;default:gen_random_uuid();column:id"`
-	StackID   *uuid.UUID                `gorm:"column:stack_id;nullable;references:ID"`
-	Stack     Stack                     `gorm:"foreignKey:StackID"`
-	Step      string                    `gorm:"column:step;not null"`
-	Status    entities.DeploymentStatus `gorm:"column:status;not null"`
-	Config    datatypes.JSON            `gorm:"type:jsonb;not null;column:config"`
-	LogPath   string                    `gorm:"column:log_path"`
-	CreatedAt time.Time                 `gorm:"autoCreateTime;column:created_at"`
-	UpdatedAt time.Time                 `gorm:"autoUpdateTime;column:updated_at"`
-	DeletedAt gorm.DeletedAt            `gorm:"column:deleted_at;default:null"`
+	ID         uuid.UUID                    `gorm:"type:uuid;primaryKey;default:gen_random_uuid();column:id"`
+	StackID    *uuid.UUID                   `gorm:"column:stack_id;nullable;references:ID"`
+	Stack      Stack                        `gorm:"foreignKey:StackID"`
+	Step       string                       `gorm:"column:step;not null"`
+	Status     entities.DeploymentRunStatus `gorm:"column:status;not null"`
+	Config     datatypes.JSON               `gorm:"type:jsonb;not null;column:config"`
+	LogPath    string                       `gorm:"column:log_path"`
+	StartedAt  *time.Time                   `gorm:"column:started_at;default:null"`
+	FinishedAt *time.Time                   `gorm:"column:finished_at;default:null"`
+	CreatedAt  time.Time                    `gorm:"autoCreateTime;column:created_at"`
+	UpdatedAt  time.Time                    `gorm:"autoUpdateTime;column:updated_at"`
+	DeletedAt  gorm.DeletedAt               `gorm:"column:deleted_at;default:null"`
 }
 
 func (Deployment) TableName() string {

--- a/pkg/infrastructure/postgres/schemas/deployment.go
+++ b/pkg/infrastructure/postgres/schemas/deployment.go
@@ -13,7 +13,7 @@ type Deployment struct {
 	ID        uuid.UUID                 `gorm:"type:uuid;primaryKey;default:gen_random_uuid();column:id"`
 	StackID   *uuid.UUID                `gorm:"column:stack_id;nullable;references:ID"`
 	Stack     Stack                     `gorm:"foreignKey:StackID"`
-	Step      int                       `gorm:"column:step;not null"`
+	Step      string                    `gorm:"column:step;not null"`
 	Status    entities.DeploymentStatus `gorm:"column:status;not null"`
 	Config    datatypes.JSON            `gorm:"type:jsonb;not null;column:config"`
 	LogPath   string                    `gorm:"column:log_path"`

--- a/pkg/infrastructure/postgres/schemas/log.go
+++ b/pkg/infrastructure/postgres/schemas/log.go
@@ -1,0 +1,28 @@
+package schemas
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Log represents a single deployment log entry.
+// Fields:
+// - id (uuid)
+// - stack_id (uuid)
+// - deployment_id (uuid)
+// - message (text)
+// - created_at (timestamp)
+type Log struct {
+	ID           uuid.UUID   `gorm:"type:uuid;primaryKey;default:gen_random_uuid();column:id"`
+	StackID      *uuid.UUID  `gorm:"column:stack_id;not null;references:ID;index:idx_logs_stack_id"`
+	Stack        *Stack      `gorm:"foreignKey:StackID"`
+	DeploymentID *uuid.UUID  `gorm:"column:deployment_id;not null;references:ID;index:idx_logs_deployment_id"`
+	Deployment   *Deployment `gorm:"foreignKey:DeploymentID"`
+	Message      string      `gorm:"column:message;type:text;not null"`
+	CreatedAt    time.Time   `gorm:"autoCreateTime;column:created_at;index:idx_logs_created_at"`
+}
+
+func (Log) TableName() string {
+	return "logs"
+}

--- a/pkg/services/thanos/deployment.go
+++ b/pkg/services/thanos/deployment.go
@@ -233,7 +233,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				return
 			}
 			// If we've processed all deployments successfully, send nil to errChan
-			if status.Status == entities.DeploymentStatusCompleted {
+			if status.Status == entities.DeploymentRunStatusSuccess {
 				select {
 				case errChan <- nil:
 				default:
@@ -249,7 +249,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 			zap.String("step", deployment.Step))
 
 		// Skip already completed deployments
-		if deployment.Status == entities.DeploymentStatusCompleted {
+		if deployment.Status == entities.DeploymentRunStatusSuccess {
 			continue
 		}
 
@@ -269,7 +269,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				zap.Error(err))
 			statusChan <- entities.DeploymentStatusWithID{
 				DeploymentID: deployment.ID,
-				Status:       entities.DeploymentStatusFailed,
+				Status:       entities.DeploymentRunStatusFailed,
 			}
 			return err
 		}
@@ -277,7 +277,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 		// Update status to in-progress before starting deployment
 		statusChan <- entities.DeploymentStatusWithID{
 			DeploymentID: deployment.ID,
-			Status:       entities.DeploymentStatusInProgress,
+			Status:       entities.DeploymentRunStatusInProgress,
 		}
 
 		switch deployment.Step {
@@ -296,10 +296,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 					logger.Info("deployment cancelled",
 						zap.String("deploymentId", deployment.ID.String()),
 						zap.String("step", deployment.Step))
-					statusChan <- entities.DeploymentStatusWithID{
-						DeploymentID: deployment.ID,
-						Status:       entities.DeploymentStatusStopped,
-					}
+					// Keep run status as-is on cancel; no explicit Stopped state in run status
 					cancel()
 					return err
 				}
@@ -309,14 +306,14 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 					zap.Error(err))
 				statusChan <- entities.DeploymentStatusWithID{
 					DeploymentID: deployment.ID,
-					Status:       entities.DeploymentStatusFailed,
+					Status:       entities.DeploymentRunStatusFailed,
 				}
 				cancel()
 				return err
 			}
 			statusChan <- entities.DeploymentStatusWithID{
 				DeploymentID: deployment.ID,
-				Status:       entities.DeploymentStatusCompleted,
+				Status:       entities.DeploymentRunStatusSuccess,
 			}
 			cancel()
 		case "deploy-aws-infra":
@@ -334,10 +331,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 					logger.Info("deployment cancelled",
 						zap.String("deploymentId", deployment.ID.String()),
 						zap.String("step", deployment.Step))
-					statusChan <- entities.DeploymentStatusWithID{
-						DeploymentID: deployment.ID,
-						Status:       entities.DeploymentStatusStopped,
-					}
+					// Keep run status as-is on cancel; no explicit Stopped state in run status
 					cancel()
 					return err
 				}
@@ -347,14 +341,14 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 					zap.Error(err))
 				statusChan <- entities.DeploymentStatusWithID{
 					DeploymentID: deployment.ID,
-					Status:       entities.DeploymentStatusFailed,
+					Status:       entities.DeploymentRunStatusFailed,
 				}
 				cancel()
 				return err
 			}
 			statusChan <- entities.DeploymentStatusWithID{
 				DeploymentID: deployment.ID,
-				Status:       entities.DeploymentStatusCompleted,
+				Status:       entities.DeploymentRunStatusSuccess,
 			}
 			cancel()
 		}

--- a/pkg/services/thanos/deployment.go
+++ b/pkg/services/thanos/deployment.go
@@ -287,6 +287,10 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				return fmt.Errorf("failed to unmarshal deployment config: %w", err)
 			}
 
+			// Start log ingestion for this deployment step
+			ingestCtx, cancel := context.WithCancel(ctx)
+			go s.tailAndIngestDeploymentLogs(ingestCtx, stack.ID, deployment.ID, deployment.LogPath)
+
 			if err := thanos.DeployL1Contracts(ctx, sdkClient, &deployL1ContractsConfig); err != nil {
 				if err == context.Canceled {
 					logger.Info("deployment cancelled",
@@ -296,6 +300,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 						DeploymentID: deployment.ID,
 						Status:       entities.DeploymentStatusStopped,
 					}
+					cancel()
 					return err
 				}
 				logger.Error("deployment failed",
@@ -306,17 +311,23 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 					DeploymentID: deployment.ID,
 					Status:       entities.DeploymentStatusFailed,
 				}
+				cancel()
 				return err
 			}
 			statusChan <- entities.DeploymentStatusWithID{
 				DeploymentID: deployment.ID,
 				Status:       entities.DeploymentStatusCompleted,
 			}
+			cancel()
 		case 2:
 			var deployAwsInfraConfig dtos.DeployThanosAWSInfraRequest
 			if err := json.Unmarshal(deployment.Config, &deployAwsInfraConfig); err != nil {
 				return fmt.Errorf("failed to unmarshal deployment config: %w", err)
 			}
+
+			// Start log ingestion for this deployment step
+			ingestCtx, cancel := context.WithCancel(ctx)
+			go s.tailAndIngestDeploymentLogs(ingestCtx, stack.ID, deployment.ID, deployment.LogPath)
 
 			if err := thanos.DeployAWSInfrastructure(ctx, sdkClient, &deployAwsInfraConfig); err != nil {
 				if err == context.Canceled {
@@ -327,6 +338,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 						DeploymentID: deployment.ID,
 						Status:       entities.DeploymentStatusStopped,
 					}
+					cancel()
 					return err
 				}
 				logger.Error("deployment failed",
@@ -337,12 +349,14 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 					DeploymentID: deployment.ID,
 					Status:       entities.DeploymentStatusFailed,
 				}
+				cancel()
 				return err
 			}
 			statusChan <- entities.DeploymentStatusWithID{
 				DeploymentID: deployment.ID,
 				Status:       entities.DeploymentStatusCompleted,
 			}
+			cancel()
 		}
 
 	}

--- a/pkg/services/thanos/deployment.go
+++ b/pkg/services/thanos/deployment.go
@@ -224,6 +224,34 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 		return fmt.Errorf("no deployments found for stacks %s", stackId)
 	}
 
+	// Filter to only the core deployment steps we want to execute here
+	filtered := make([]*entities.DeploymentEntity, 0, 2)
+	var l1Step, awsStep *entities.DeploymentEntity
+	for _, d := range deployments {
+		if d.Step == "deploy-l1-contracts" {
+			// keep the earliest unfinished occurrence
+			if l1Step == nil || (l1Step.Status == entities.DeploymentRunStatusSuccess && d.Status != entities.DeploymentRunStatusSuccess) {
+				l1Step = d
+			}
+		}
+		if d.Step == "deploy-aws-infra" {
+			if awsStep == nil || (awsStep.Status == entities.DeploymentRunStatusSuccess && d.Status != entities.DeploymentRunStatusSuccess) {
+				awsStep = d
+			}
+		}
+	}
+	if l1Step != nil {
+		filtered = append(filtered, l1Step)
+	}
+	if awsStep != nil {
+		filtered = append(filtered, awsStep)
+	}
+
+	// Overwrite deployments with filtered list to enforce order L1 first then AWS infra
+	if len(filtered) > 0 {
+		deployments = filtered
+	}
+
 	// Start a goroutine to handle status updates
 	errChan := make(chan error, 1)
 	go func() {

--- a/pkg/services/thanos/deployment.go
+++ b/pkg/services/thanos/deployment.go
@@ -246,7 +246,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 		logger.Info("Processing deployment",
 			zap.String("deploymentId", deployment.ID.String()),
 			zap.String("status", string(deployment.Status)),
-			zap.Int("step", deployment.Step))
+			zap.String("step", deployment.Step))
 
 		// Skip already completed deployments
 		if deployment.Status == entities.DeploymentStatusCompleted {
@@ -281,7 +281,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 		}
 
 		switch deployment.Step {
-		case 1:
+		case "deploy-l1-contracts":
 			var deployL1ContractsConfig dtos.DeployL1ContractsRequest
 			if err := json.Unmarshal(deployment.Config, &deployL1ContractsConfig); err != nil {
 				return fmt.Errorf("failed to unmarshal deployment config: %w", err)
@@ -295,7 +295,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				if err == context.Canceled {
 					logger.Info("deployment cancelled",
 						zap.String("deploymentId", deployment.ID.String()),
-						zap.Int("step", deployment.Step))
+						zap.String("step", deployment.Step))
 					statusChan <- entities.DeploymentStatusWithID{
 						DeploymentID: deployment.ID,
 						Status:       entities.DeploymentStatusStopped,
@@ -305,7 +305,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				}
 				logger.Error("deployment failed",
 					zap.String("deploymentId", deployment.ID.String()),
-					zap.Int("step", deployment.Step),
+					zap.String("step", deployment.Step),
 					zap.Error(err))
 				statusChan <- entities.DeploymentStatusWithID{
 					DeploymentID: deployment.ID,
@@ -319,7 +319,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				Status:       entities.DeploymentStatusCompleted,
 			}
 			cancel()
-		case 2:
+		case "deploy-aws-infra":
 			var deployAwsInfraConfig dtos.DeployThanosAWSInfraRequest
 			if err := json.Unmarshal(deployment.Config, &deployAwsInfraConfig); err != nil {
 				return fmt.Errorf("failed to unmarshal deployment config: %w", err)
@@ -333,7 +333,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				if err == context.Canceled {
 					logger.Info("deployment cancelled",
 						zap.String("deploymentId", deployment.ID.String()),
-						zap.Int("step", deployment.Step))
+						zap.String("step", deployment.Step))
 					statusChan <- entities.DeploymentStatusWithID{
 						DeploymentID: deployment.ID,
 						Status:       entities.DeploymentStatusStopped,
@@ -343,7 +343,7 @@ func (s *ThanosStackDeploymentService) deployThanosStack(ctx context.Context, st
 				}
 				logger.Error("deployment failed",
 					zap.String("deploymentId", deployment.ID.String()),
-					zap.Int("step", deployment.Step),
+					zap.String("step", deployment.Step),
 					zap.Error(err))
 				statusChan <- entities.DeploymentStatusWithID{
 					DeploymentID: deployment.ID,

--- a/pkg/services/thanos/helpers.go
+++ b/pkg/services/thanos/helpers.go
@@ -1,19 +1,12 @@
 package thanos
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/tokamak-network/trh-backend/internal/logger"
 	"github.com/tokamak-network/trh-backend/internal/utils"
 	"github.com/tokamak-network/trh-backend/pkg/api/dtos"
 	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
-	"github.com/tokamak-network/trh-backend/pkg/enum"
-	"github.com/tokamak-network/trh-backend/pkg/stacks/thanos"
-	"go.uber.org/zap"
 )
 
 func getThanosStackDeployments(
@@ -80,149 +73,5 @@ func getThanosStackDeployments(
 	return deployments, nil
 }
 
-func (s *ThanosStackDeploymentService) RegisterCandidate(ctx context.Context, stackId uuid.UUID, req dtos.RegisterCandidateRequest) (*entities.Response, error) {
-	stack, err := s.stackRepo.GetStackByID(stackId.String())
-	if err != nil {
-		logger.Error("failed to get stack by id", zap.Error(err))
-		return &entities.Response{
-			Status:  http.StatusInternalServerError,
-			Message: "Internal server error",
-			Data:    nil,
-		}, err
-	}
-
-	if stack == nil {
-		return &entities.Response{
-			Status:  http.StatusNotFound,
-			Message: "Stack not found",
-			Data:    nil,
-		}, nil
-	}
-
-	if stack.Status != entities.StackStatusDeployed {
-		return &entities.Response{
-			Status:  http.StatusBadRequest,
-			Message: "Stack has not been deployed yet",
-			Data:    nil,
-		}, nil
-	}
-
-	// check if register candidate is already in non-terminated state
-	integrations, err := s.integrationRepo.GetActiveIntegrations(stackId.String(), enum.IntegrationTypeRegisterCandidate.String())
-	if err != nil {
-		logger.Error("failed to get integration", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err))
-		return &entities.Response{
-			Status:  http.StatusInternalServerError,
-			Message: "Internal server error",
-			Data:    nil,
-		}, err
-	}
-
-	if len(integrations) > 0 {
-		logger.Error("There is already an active register candidate", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()))
-		return &entities.Response{
-			Status:  http.StatusBadRequest,
-			Message: "There is already an active register candidate",
-			Data:    nil,
-		}, nil
-	}
-
-	stackConfig := dtos.DeployThanosRequest{}
-	err = json.Unmarshal(stack.Config, &stackConfig)
-	if err != nil {
-		logger.Error("failed to unmarshal stack config", zap.Error(err))
-		return &entities.Response{
-			Status:  http.StatusInternalServerError,
-			Message: "Internal server error",
-			Data:    nil,
-		}, err
-	}
-
-	registerCandidateLogPath := utils.GetLogPath(stackId, "register-candidate")
-	sdkClient, err := thanos.NewThanosSDKClient(
-		ctx,
-		registerCandidateLogPath,
-		string(stack.Network),
-		stack.DeploymentPath,
-		stackConfig.RegisterCandidate,
-		stackConfig.AwsAccessKey,
-		stackConfig.AwsSecretAccessKey,
-		stackConfig.AwsRegion,
-	)
-	if err != nil {
-		logger.Error("failed to create thanos sdk client", zap.Error(err))
-		return &entities.Response{
-			Status:  http.StatusInternalServerError,
-			Message: "Internal server error",
-			Data:    nil,
-		}, err
-	}
-
-	taskId := fmt.Sprintf("register-candidate-%s", stackId.String())
-
-	s.taskManager.AddTask(taskId, func(ctx context.Context) {
-		integrationConfig, err := json.Marshal(req)
-		if err != nil {
-			logger.Error("failed to marshal integration config", zap.Error(err))
-			return
-		}
-
-		integrationId := uuid.New()
-		integration := &entities.IntegrationEntity{
-			ID:      integrationId,
-			StackID: &stackId,
-			Type:    enum.IntegrationTypeRegisterCandidate.String(),
-			Status:  string(entities.DeploymentStatusPending),
-			Config:  integrationConfig,
-			LogPath: registerCandidateLogPath,
-		}
-		err = s.integrationRepo.CreateIntegration(integration)
-		if err != nil {
-			logger.Error("failed to create integration", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err))
-			return
-		}
-		err = thanos.VerifyRegisterCandidates(ctx, sdkClient, &req)
-		if err != nil {
-			logger.Error("failed to register candidate", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err), zap.String("stackId", stackId.String()))
-			err = s.integrationRepo.UpdateIntegrationStatusWithReason(integrationId.String(), entities.DeploymentStatusFailed, err.Error())
-			if err != nil {
-				logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err), zap.String("integrationId", integrationId.String()))
-			}
-			return
-		}
-		err = s.integrationRepo.UpdateIntegrationStatus(integrationId.String(), entities.DeploymentStatusCompleted)
-		if err != nil {
-			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err), zap.String("integrationId", integrationId.String()))
-		}
-
-		registerCandidateInfo, err := thanos.GetRegisterCandidatesInfo(ctx, sdkClient, &req)
-		if err != nil {
-			logger.Error("failed to get register candidate info", zap.Error(err))
-			return
-		}
-
-		bytes, err := json.Marshal(registerCandidateInfo)
-		if err != nil {
-			logger.Error("failed to marshal register candidate info", zap.Error(err))
-			return
-		}
-
-		err = s.integrationRepo.UpdateMetadataAfterInstalled(
-			integrationId.String(),
-			bytes,
-		)
-
-		if err != nil {
-			logger.Error("failed to update register candidate integration metadata", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err))
-			return
-		}
-
-		logger.Info("Register candidate successfully", zap.String("stackId", stackId.String()))
-	})
-
-	return &entities.Response{
-		Status:  http.StatusOK,
-		Message: "Candidate registered successfully",
-		Data:    nil,
-	}, nil
-}
+// RegisterCandidate moved to pkg/services/thanos/integrations/register_candidate.go and is exposed via
+// ThanosStackDeploymentService.RegisterCandidate in service.go

--- a/pkg/services/thanos/helpers.go
+++ b/pkg/services/thanos/helpers.go
@@ -49,7 +49,7 @@ func getThanosStackDeployments(
 		ID:      l1ContractDeploymentID,
 		StackID: &stackId,
 		Step:    "deploy-l1-contracts",
-		Status:  entities.DeploymentStatusPending,
+		Status:  entities.DeploymentRunStatusNotStarted,
 		LogPath: l1ContractDeploymentLogPath,
 		Config:  l1ContractDeploymentConfig,
 	}
@@ -71,7 +71,7 @@ func getThanosStackDeployments(
 		ID:      thanosInfrastructureDeploymentID,
 		StackID: &stackId,
 		Step:    "deploy-aws-infra",
-		Status:  entities.DeploymentStatusPending,
+		Status:  entities.DeploymentRunStatusNotStarted,
 		LogPath: thanosInfrastructureDeploymentLogPath,
 		Config:  thanosInfrastructureDeploymentConfig,
 	}

--- a/pkg/services/thanos/helpers.go
+++ b/pkg/services/thanos/helpers.go
@@ -48,7 +48,7 @@ func getThanosStackDeployments(
 	l1ContractDeployment := &entities.DeploymentEntity{
 		ID:      l1ContractDeploymentID,
 		StackID: &stackId,
-		Step:    1,
+		Step:    "deploy-l1-contracts",
 		Status:  entities.DeploymentStatusPending,
 		LogPath: l1ContractDeploymentLogPath,
 		Config:  l1ContractDeploymentConfig,
@@ -70,7 +70,7 @@ func getThanosStackDeployments(
 	thanosInfrastructureDeployment := &entities.DeploymentEntity{
 		ID:      thanosInfrastructureDeploymentID,
 		StackID: &stackId,
-		Step:    2,
+		Step:    "deploy-aws-infra",
 		Status:  entities.DeploymentStatusPending,
 		LogPath: thanosInfrastructureDeploymentLogPath,
 		Config:  thanosInfrastructureDeploymentConfig,

--- a/pkg/services/thanos/integrations/block_explorer.go
+++ b/pkg/services/thanos/integrations/block_explorer.go
@@ -23,6 +23,10 @@ type BlockExplorerIntegration struct {
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	}
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	}
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -43,6 +47,10 @@ func NewBlockExplorerIntegration(
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	},
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	},
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -58,6 +66,7 @@ func NewBlockExplorerIntegration(
 ) *BlockExplorerIntegration {
 	return &BlockExplorerIntegration{
 		stackRepo:       stackRepo,
+		deploymentRepo:  deploymentRepo,
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
 	}
@@ -212,7 +221,7 @@ func (b *BlockExplorerIntegration) Uninstall(ctx context.Context, stackId string
 
 	taskId := fmt.Sprintf("uninstall-block-explorer-%s", stackId)
 	b.taskManager.AddTask(taskId, func(ctx context.Context) {
-		b.uninstallTask(ctx, stack, sdkClient, stackId)
+		b.uninstallTask(ctx, stack, sdkClient, stackId, logPath)
 	})
 
 	return &entities.Response{
@@ -227,6 +236,25 @@ func (b *BlockExplorerIntegration) installTask(ctx context.Context, stack *entit
 	configBytes, err := json.Marshal(request)
 	if err != nil {
 		logger.Error("failed to marshal block explorer config", zap.Error(err))
+		return
+	}
+
+	// Create deployment record for installing block explorer
+	deployment := &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stack.ID,
+		Step:    "install-block-explorer",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  configBytes,
+	}
+	if err := b.deploymentRepo.CreateDeployment(deployment); err != nil {
+		logger.Error("failed to create deployment record", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
+		return
+	}
+	// Mark deployment as in-progress to set started_at
+	if err := b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set deployment in-progress", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
 		return
 	}
 
@@ -258,6 +286,7 @@ func (b *BlockExplorerIntegration) installTask(ctx context.Context, stack *entit
 		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(blockExplorerIntegration.ID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(updateErr), zap.String("integrationId", blockExplorerIntegration.ID.String()))
 		}
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -266,6 +295,7 @@ func (b *BlockExplorerIntegration) installTask(ctx context.Context, stack *entit
 		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(blockExplorerIntegration.ID.String(), entities.DeploymentStatusFailed, "Block explorer URL is empty"); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(updateErr), zap.String("integrationId", blockExplorerIntegration.ID.String()))
 		}
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -285,19 +315,37 @@ func (b *BlockExplorerIntegration) installTask(ctx context.Context, stack *entit
 
 	if err = b.integrationRepo.UpdateMetadataAfterInstalled(blockExplorerIntegration.ID.String(), entities.IntegrationInfo(metadataBytes)); err != nil {
 		logger.Error("failed to create integration", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
 	stack.Metadata.ExplorerUrl = blockExplorerUrl
 	if err = b.stackRepo.UpdateMetadata(stack.ID.String(), stack.Metadata); err != nil {
 		logger.Error("failed to update stack metadata", zap.String("stackId", stack.ID.String()), zap.Error(err))
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
+
+	_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }
 
 // uninstallTask handles the actual uninstallation process
-func (b *BlockExplorerIntegration) uninstallTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, stackId string) {
-	integration, err := b.integrationRepo.GetInstalledIntegration(stackId, enum.IntegrationTypeBlockExplorer.String())
+func (b *BlockExplorerIntegration) uninstallTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, stackId string, logPath string) {
+	var uninstallDeployment *entities.DeploymentEntity
+	var integration *entities.IntegrationEntity
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("panic during block-explorer uninstall", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Any("recover", r))
+			if uninstallDeployment != nil {
+				_ = b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusFailed)
+			}
+			if integration != nil {
+				_ = b.integrationRepo.UpdateIntegrationStatusWithReason(integration.ID.String(), entities.DeploymentStatusFailed, fmt.Sprint(r))
+			}
+		}
+	}()
+	var err error
+	integration, err = b.integrationRepo.GetInstalledIntegration(stackId, enum.IntegrationTypeBlockExplorer.String())
 	if err != nil {
 		logger.Error("failed to get integration", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
 		return
@@ -318,8 +366,28 @@ func (b *BlockExplorerIntegration) uninstallTask(ctx context.Context, stack *ent
 		logger.Error("failed to type assert sdkClient for uninstall", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()))
 		return
 	}
+	// Create deployment record for uninstalling block explorer
+	uninstallDeployment = &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stack.ID,
+		Step:    "uninstall-block-explorer",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  []byte("{}"),
+	}
+	if err := b.deploymentRepo.CreateDeployment(uninstallDeployment); err != nil {
+		logger.Error("failed to create uninstall deployment record", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
+		return
+	}
+	if err := b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set uninstall deployment in-progress", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
+		return
+	}
+
 	if err = thanos.UninstallBlockExplorer(ctx, thanosClient); err != nil {
 		logger.Error("failed to uninstall block-explorer", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
+		_ = b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusFailed)
+		_ = b.integrationRepo.UpdateIntegrationStatusWithReason(integration.ID.String(), entities.DeploymentStatusFailed, err.Error())
 		return
 	}
 
@@ -333,4 +401,6 @@ func (b *BlockExplorerIntegration) uninstallTask(ctx context.Context, stack *ent
 		logger.Error("failed to update stack metadata", zap.String("stackId", stackId), zap.Error(err))
 		return
 	}
+
+	_ = b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }

--- a/pkg/services/thanos/integrations/bridge.go
+++ b/pkg/services/thanos/integrations/bridge.go
@@ -23,6 +23,10 @@ type BridgeIntegration struct {
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	}
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	}
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -43,6 +47,10 @@ func NewBridgeIntegration(
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	},
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	},
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -58,6 +66,7 @@ func NewBridgeIntegration(
 ) *BridgeIntegration {
 	return &BridgeIntegration{
 		stackRepo:       stackRepo,
+		deploymentRepo:  deploymentRepo,
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
 	}
@@ -203,7 +212,7 @@ func (b *BridgeIntegration) Uninstall(ctx context.Context, stackId string) (*ent
 
 	taskId := fmt.Sprintf("uninstall-bridge-%s", stackId)
 	b.taskManager.AddTask(taskId, func(ctx context.Context) {
-		b.uninstallTask(ctx, stack, sdkClient, stackId)
+		b.uninstallTask(ctx, stack, sdkClient, stackId, logPath)
 	})
 
 	return &entities.Response{
@@ -215,6 +224,24 @@ func (b *BridgeIntegration) Uninstall(ctx context.Context, stackId string) (*ent
 
 // installTask handles the actual installation process
 func (b *BridgeIntegration) installTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, logPath string) {
+	// Create deployment record for installing bridge
+	deployment := &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stack.ID,
+		Step:    "install-bridge",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  []byte("{}"),
+	}
+	if err := b.deploymentRepo.CreateDeployment(deployment); err != nil {
+		logger.Error("failed to create deployment record", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
+		return
+	}
+	if err := b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set deployment in-progress", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
+		return
+	}
+
 	bridgeIntegration := &entities.IntegrationEntity{
 		ID:      uuid.New(),
 		StackID: &stack.ID,
@@ -244,6 +271,7 @@ func (b *BridgeIntegration) installTask(ctx context.Context, stack *entities.Sta
 		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(bridgeIntegration.ID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(updateErr), zap.String("integrationId", bridgeIntegration.ID.String()))
 		}
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -252,6 +280,7 @@ func (b *BridgeIntegration) installTask(ctx context.Context, stack *entities.Sta
 		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(bridgeIntegration.ID.String(), entities.DeploymentStatusFailed, "Bridge URL is empty"); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(updateErr), zap.String("integrationId", bridgeIntegration.ID.String()))
 		}
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -277,19 +306,37 @@ func (b *BridgeIntegration) installTask(ctx context.Context, stack *entities.Sta
 
 	if err = b.integrationRepo.UpdateMetadataAfterInstalled(bridgeIntegration.ID.String(), entities.IntegrationInfo(bytes)); err != nil {
 		logger.Error("failed to create integration", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
 	stack.Metadata.BridgeUrl = bridgeUrl
 	if err = b.stackRepo.UpdateMetadata(stack.ID.String(), stack.Metadata); err != nil {
 		logger.Error("failed to update stack metadata", zap.String("stackId", stack.ID.String()), zap.Error(err))
+		_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
+
+	_ = b.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }
 
 // uninstallTask handles the actual uninstallation process
-func (b *BridgeIntegration) uninstallTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, stackId string) {
-	integration, err := b.integrationRepo.GetInstalledIntegration(stackId, enum.IntegrationTypeBridge.String())
+func (b *BridgeIntegration) uninstallTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, stackId string, logPath string) {
+	var uninstallDeployment *entities.DeploymentEntity
+	var integration *entities.IntegrationEntity
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("panic during bridge uninstall", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Any("recover", r))
+			if uninstallDeployment != nil {
+				_ = b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusFailed)
+			}
+			if integration != nil {
+				_ = b.integrationRepo.UpdateIntegrationStatusWithReason(integration.ID.String(), entities.DeploymentStatusFailed, fmt.Sprint(r))
+			}
+		}
+	}()
+	var err error
+	integration, err = b.integrationRepo.GetInstalledIntegration(stackId, enum.IntegrationTypeBridge.String())
 	if err != nil {
 		logger.Error("failed to get integration", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
 		return
@@ -311,8 +358,28 @@ func (b *BridgeIntegration) uninstallTask(ctx context.Context, stack *entities.S
 		return
 	}
 
+	// Create deployment record for uninstalling bridge
+	uninstallDeployment = &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stack.ID,
+		Step:    "uninstall-bridge",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  []byte("{}"),
+	}
+	if err := b.deploymentRepo.CreateDeployment(uninstallDeployment); err != nil {
+		logger.Error("failed to create uninstall deployment record", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
+		return
+	}
+	if err := b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set uninstall deployment in-progress", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
+		return
+	}
+
 	if err = thanos.UninstallBridge(ctx, thanosClient); err != nil {
 		logger.Error("failed to uninstall bridge", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
+		_ = b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusFailed)
+		_ = b.integrationRepo.UpdateIntegrationStatusWithReason(integration.ID.String(), entities.DeploymentStatusFailed, err.Error())
 		return
 	}
 
@@ -326,4 +393,6 @@ func (b *BridgeIntegration) uninstallTask(ctx context.Context, stack *entities.S
 		logger.Error("failed to update stack metadata", zap.String("stackId", stackId), zap.Error(err))
 		return
 	}
+
+	_ = b.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }

--- a/pkg/services/thanos/integrations/interfaces.go
+++ b/pkg/services/thanos/integrations/interfaces.go
@@ -23,6 +23,10 @@ func NewIntegrationManager(
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	},
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	},
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -37,10 +41,10 @@ func NewIntegrationManager(
 	},
 ) *IntegrationManager {
 	return &IntegrationManager{
-		blockExplorer:     NewBlockExplorerIntegration(stackRepo, integrationRepo, taskManager),
-		bridge:            NewBridgeIntegration(stackRepo, integrationRepo, taskManager),
-		monitoring:        NewMonitoringIntegration(stackRepo, integrationRepo, taskManager),
-		registerCandidate: NewRegisterCandidateIntegration(stackRepo, integrationRepo, taskManager),
+		blockExplorer:     NewBlockExplorerIntegration(stackRepo, deploymentRepo, integrationRepo, taskManager),
+		bridge:            NewBridgeIntegration(stackRepo, deploymentRepo, integrationRepo, taskManager),
+		monitoring:        NewMonitoringIntegration(stackRepo, deploymentRepo, integrationRepo, taskManager),
+		registerCandidate: NewRegisterCandidateIntegration(stackRepo, deploymentRepo, integrationRepo, taskManager),
 	}
 }
 

--- a/pkg/services/thanos/integrations/monitoring.go
+++ b/pkg/services/thanos/integrations/monitoring.go
@@ -23,6 +23,10 @@ type MonitoringIntegration struct {
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	}
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	}
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -43,6 +47,10 @@ func NewMonitoringIntegration(
 		GetStackByID(id string) (*entities.StackEntity, error)
 		UpdateMetadata(id string, metadata *entities.StackMetadata) error
 	},
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	},
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -58,6 +66,7 @@ func NewMonitoringIntegration(
 ) *MonitoringIntegration {
 	return &MonitoringIntegration{
 		stackRepo:       stackRepo,
+		deploymentRepo:  deploymentRepo,
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
 	}
@@ -203,7 +212,7 @@ func (m *MonitoringIntegration) Uninstall(ctx context.Context, stackId uuid.UUID
 
 	taskId := fmt.Sprintf("uninstall-monitoring-%s", stackId)
 	m.taskManager.AddTask(taskId, func(ctx context.Context) {
-		m.uninstallTask(ctx, stack, sdkClient, stackId.String())
+		m.uninstallTask(ctx, stack, sdkClient, stackId.String(), logPath)
 	})
 
 	return &entities.Response{
@@ -218,6 +227,24 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, stack *entities
 	configBytes, err := json.Marshal(req)
 	if err != nil {
 		logger.Error("failed to marshal monitoring config", zap.Error(err))
+		return
+	}
+
+	// Create deployment record for installing monitoring
+	deployment := &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stack.ID,
+		Step:    "install-monitoring",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  configBytes,
+	}
+	if err := m.deploymentRepo.CreateDeployment(deployment); err != nil {
+		logger.Error("failed to create deployment record", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
+		return
+	}
+	if err := m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set deployment in-progress", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
 		return
 	}
 
@@ -250,6 +277,7 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, stack *entities
 		if updateErr := m.integrationRepo.UpdateIntegrationStatusWithReason(monitoringIntegration.ID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(updateErr), zap.String("integrationId", monitoringIntegration.ID.String()))
 		}
+		_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -259,6 +287,7 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, stack *entities
 		if updateErr := m.integrationRepo.UpdateIntegrationStatusWithReason(monitoringIntegration.ID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(updateErr), zap.String("integrationId", monitoringIntegration.ID.String()))
 		}
+		_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -267,6 +296,7 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, stack *entities
 		if updateErr := m.integrationRepo.UpdateIntegrationStatusWithReason(monitoringIntegration.ID.String(), entities.DeploymentStatusFailed, "Failed to install monitoring"); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(updateErr), zap.String("integrationId", monitoringIntegration.ID.String()))
 		}
+		_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -275,6 +305,7 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, stack *entities
 		if updateErr := m.integrationRepo.UpdateIntegrationStatusWithReason(monitoringIntegration.ID.String(), entities.DeploymentStatusFailed, "Monitoring URL is empty"); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(updateErr), zap.String("integrationId", monitoringIntegration.ID.String()))
 		}
+		_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -305,19 +336,37 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, stack *entities
 
 	if err = m.integrationRepo.UpdateMetadataAfterInstalled(monitoringIntegration.ID.String(), entities.IntegrationInfo(bytes)); err != nil {
 		logger.Error("failed to create integration", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
+		_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
 	stack.Metadata.GrafanaUrl = monitoringInfo.GrafanaURL
 	if err = m.stackRepo.UpdateMetadata(stackId, stack.Metadata); err != nil {
 		logger.Error("failed to update stack metadata", zap.String("stackId", stackId), zap.Error(err))
+		_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
+
+	_ = m.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }
 
 // uninstallTask handles the actual uninstallation process
-func (m *MonitoringIntegration) uninstallTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, stackId string) {
-	integration, err := m.integrationRepo.GetInstalledIntegration(stackId, enum.IntegrationTypeMonitoring.String())
+func (m *MonitoringIntegration) uninstallTask(ctx context.Context, stack *entities.StackEntity, sdkClient interface{}, stackId string, logPath string) {
+	var uninstallDeployment *entities.DeploymentEntity
+	var integration *entities.IntegrationEntity
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("panic during monitoring uninstall", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Any("recover", r))
+			if uninstallDeployment != nil {
+				_ = m.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusFailed)
+			}
+			if integration != nil {
+				_ = m.integrationRepo.UpdateIntegrationStatusWithReason(integration.ID.String(), entities.DeploymentStatusFailed, fmt.Sprint(r))
+			}
+		}
+	}()
+	var err error
+	integration, err = m.integrationRepo.GetInstalledIntegration(stackId, enum.IntegrationTypeMonitoring.String())
 	if err != nil {
 		logger.Error("failed to get integration", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
 		return
@@ -339,8 +388,28 @@ func (m *MonitoringIntegration) uninstallTask(ctx context.Context, stack *entiti
 		return
 	}
 
+	// Create deployment record for uninstalling monitoring
+	uninstallDeployment = &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stack.ID,
+		Step:    "uninstall-monitoring",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  []byte("{}"),
+	}
+	if err := m.deploymentRepo.CreateDeployment(uninstallDeployment); err != nil {
+		logger.Error("failed to create uninstall deployment record", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
+		return
+	}
+	if err := m.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set uninstall deployment in-progress", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
+		return
+	}
+
 	if err = thanos.UninstallMonitoring(ctx, thanosClient); err != nil {
 		logger.Error("failed to uninstall monitoring", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
+		_ = m.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusFailed)
+		_ = m.integrationRepo.UpdateIntegrationStatusWithReason(integration.ID.String(), entities.DeploymentStatusFailed, err.Error())
 		return
 	}
 
@@ -354,4 +423,6 @@ func (m *MonitoringIntegration) uninstallTask(ctx context.Context, stack *entiti
 		logger.Error("failed to update stack metadata", zap.String("stackId", stackId), zap.Error(err))
 		return
 	}
+
+	_ = m.deploymentRepo.UpdateDeploymentStatus(uninstallDeployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }

--- a/pkg/services/thanos/integrations/register_candidate.go
+++ b/pkg/services/thanos/integrations/register_candidate.go
@@ -22,6 +22,10 @@ type RegisterCandidateIntegration struct {
 	stackRepo interface {
 		GetStackByID(id string) (*entities.StackEntity, error)
 	}
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	}
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -39,6 +43,10 @@ func NewRegisterCandidateIntegration(
 	stackRepo interface {
 		GetStackByID(id string) (*entities.StackEntity, error)
 	},
+	deploymentRepo interface {
+		CreateDeployment(deployment *entities.DeploymentEntity) error
+		UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
+	},
 	integrationRepo interface {
 		GetActiveIntegrations(stackId, integrationType string) ([]*entities.IntegrationEntity, error)
 		CreateIntegration(integration *entities.IntegrationEntity) error
@@ -52,6 +60,7 @@ func NewRegisterCandidateIntegration(
 ) *RegisterCandidateIntegration {
 	return &RegisterCandidateIntegration{
 		stackRepo:       stackRepo,
+		deploymentRepo:  deploymentRepo,
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
 	}
@@ -156,6 +165,24 @@ func (r *RegisterCandidateIntegration) registerTask(ctx context.Context, stack *
 		return
 	}
 
+	// Create deployment record for register candidate
+	deployment := &entities.DeploymentEntity{
+		ID:      uuid.New(),
+		StackID: &stackId,
+		Step:    "register-candidate",
+		Status:  entities.DeploymentRunStatusNotStarted,
+		LogPath: logPath,
+		Config:  integrationConfig,
+	}
+	if err := r.deploymentRepo.CreateDeployment(deployment); err != nil {
+		logger.Error("failed to create deployment record", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err))
+		return
+	}
+	if err := r.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusInProgress); err != nil {
+		logger.Error("failed to set deployment in-progress", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(err))
+		return
+	}
+
 	integrationId := uuid.New()
 	integration := &entities.IntegrationEntity{
 		ID:      integrationId,
@@ -185,6 +212,7 @@ func (r *RegisterCandidateIntegration) registerTask(ctx context.Context, stack *
 		if updateErr := r.integrationRepo.UpdateIntegrationStatusWithReason(integrationId.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
 			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeRegisterCandidate.String()), zap.Error(updateErr), zap.String("integrationId", integrationId.String()))
 		}
+		_ = r.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusFailed)
 		return
 	}
 
@@ -210,4 +238,6 @@ func (r *RegisterCandidateIntegration) registerTask(ctx context.Context, stack *
 	}
 
 	logger.Info("Register candidate successfully", zap.String("stackId", stackId.String()))
+
+	_ = r.deploymentRepo.UpdateDeploymentStatus(deployment.ID.String(), entities.DeploymentRunStatusSuccess)
 }

--- a/pkg/services/thanos/interfaces.go
+++ b/pkg/services/thanos/interfaces.go
@@ -9,12 +9,12 @@ import (
 type DeploymentRepository interface {
 	CreateDeployment(deployment *entities.DeploymentEntity) error
 	GetDeploymentsByStackID(stackId string) ([]*entities.DeploymentEntity, error)
-	UpdateDeploymentStatus(deploymentId string, status entities.DeploymentStatus) error
+	UpdateDeploymentStatus(deploymentId string, status entities.DeploymentRunStatus) error
 	GetDeploymentByID(deploymentId string) (*entities.DeploymentEntity, error)
-	GetDeploymentStatus(deploymentId string) (entities.DeploymentStatus, error)
+	GetDeploymentStatus(deploymentId string) (entities.DeploymentRunStatus, error)
 	UpdateStatusesByStackId(
 		stackID string,
-		status entities.DeploymentStatus,
+		status entities.DeploymentRunStatus,
 	) error
 }
 

--- a/pkg/services/thanos/interfaces.go
+++ b/pkg/services/thanos/interfaces.go
@@ -82,6 +82,12 @@ type IntegrationRepository interface {
 	) error
 }
 
+type LogRepository interface {
+	CreateLog(log *entities.LogEntity) error
+	GetLogsByDeploymentID(deploymentId string, limit int, afterID *string) ([]*entities.LogEntity, error)
+	GetLogsByStackID(stackId string, limit int, afterID *string) ([]*entities.LogEntity, error)
+}
+
 type TaskManager interface {
 	Start()
 	AddTask(id string, task entities.Task)

--- a/pkg/services/thanos/interfaces.go
+++ b/pkg/services/thanos/interfaces.go
@@ -7,6 +7,7 @@ import (
 )
 
 type DeploymentRepository interface {
+	CreateDeployment(deployment *entities.DeploymentEntity) error
 	GetDeploymentsByStackID(stackId string) ([]*entities.DeploymentEntity, error)
 	UpdateDeploymentStatus(deploymentId string, status entities.DeploymentStatus) error
 	GetDeploymentByID(deploymentId string) (*entities.DeploymentEntity, error)

--- a/pkg/services/thanos/logs.go
+++ b/pkg/services/thanos/logs.go
@@ -1,0 +1,73 @@
+package thanos
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tokamak-network/trh-backend/internal/logger"
+	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
+	"go.uber.org/zap"
+)
+
+func (s *ThanosStackDeploymentService) tailAndIngestDeploymentLogs(
+	ctx context.Context,
+	stackID uuid.UUID,
+	deploymentID uuid.UUID,
+	logPath string,
+) {
+	// Wait for file to appear
+	for {
+		if _, err := os.Stat(logPath); err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		logger.Error("failed to open log file", zap.String("path", logPath), zap.Error(err))
+		return
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			line, err := reader.ReadString('\n')
+			if len(line) > 0 {
+				msg := strings.TrimRight(line, "\r\n")
+				if msg != "" {
+					l := &entities.LogEntity{
+						StackID:      &stackID,
+						DeploymentID: &deploymentID,
+						Message:      msg,
+					}
+					if dbErr := s.logRepo.CreateLog(l); dbErr != nil {
+						logger.Error("failed to insert log", zap.Error(dbErr))
+					}
+				}
+			}
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					time.Sleep(300 * time.Millisecond)
+					continue
+				}
+				logger.Error("error reading log file", zap.Error(err))
+				return
+			}
+		}
+	}
+}

--- a/pkg/services/thanos/queries.go
+++ b/pkg/services/thanos/queries.go
@@ -151,6 +151,61 @@ func (s *ThanosStackDeploymentService) GetStackDeployment(
 	}, nil
 }
 
+func (s *ThanosStackDeploymentService) GetDeploymentLogs(
+	stackId uuid.UUID,
+	deploymentId uuid.UUID,
+	limit int,
+	afterID *string,
+) (*entities.Response, error) {
+	stack, err := s.stackRepo.GetStackByID(stackId.String())
+	if err != nil {
+		logger.Error("failed to get stack", zap.String("stackId", stackId.String()), zap.Error(err))
+		return &entities.Response{Status: http.StatusInternalServerError, Message: "Internal server error"}, err
+	}
+	if stack == nil {
+		return &entities.Response{Status: http.StatusNotFound, Message: "Stack not found"}, nil
+	}
+
+	logs, err := s.logRepo.GetLogsByDeploymentID(deploymentId.String(), limit, afterID)
+	if err != nil {
+		logger.Error("failed to get logs", zap.String("deploymentId", deploymentId.String()), zap.Error(err))
+		return &entities.Response{Status: http.StatusInternalServerError, Message: "Internal server error"}, err
+	}
+
+	return &entities.Response{
+		Status:  http.StatusOK,
+		Message: "Successfully",
+		Data:    map[string]interface{}{"logs": logs},
+	}, nil
+}
+
+func (s *ThanosStackDeploymentService) GetStackLogs(
+	stackId uuid.UUID,
+	limit int,
+	afterID *string,
+) (*entities.Response, error) {
+	stack, err := s.stackRepo.GetStackByID(stackId.String())
+	if err != nil {
+		logger.Error("failed to get stack", zap.String("stackId", stackId.String()), zap.Error(err))
+		return &entities.Response{Status: http.StatusInternalServerError, Message: "Internal server error"}, err
+	}
+	if stack == nil {
+		return &entities.Response{Status: http.StatusNotFound, Message: "Stack not found"}, nil
+	}
+
+	logs, err := s.logRepo.GetLogsByStackID(stackId.String(), limit, afterID)
+	if err != nil {
+		logger.Error("failed to get logs", zap.String("stackId", stackId.String()), zap.Error(err))
+		return &entities.Response{Status: http.StatusInternalServerError, Message: "Internal server error"}, err
+	}
+
+	return &entities.Response{
+		Status:  http.StatusOK,
+		Message: "Successfully",
+		Data:    map[string]interface{}{"logs": logs},
+	}, nil
+}
+
 func (s *ThanosStackDeploymentService) GetStackByID(
 	stackId uuid.UUID,
 ) (*entities.Response, error) {

--- a/pkg/services/thanos/service.go
+++ b/pkg/services/thanos/service.go
@@ -43,7 +43,7 @@ func NewThanosService(
 		stackRepo:       stackRepo,
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
-        integrationMgr:  integrations.NewIntegrationManager(stackRepo, deploymentRepo, integrationRepo, taskManagerWrapper),
+		integrationMgr:  integrations.NewIntegrationManager(stackRepo, deploymentRepo, integrationRepo, taskManagerWrapper),
 		logRepo:         logRepo,
 	}
 
@@ -80,4 +80,9 @@ func (s *ThanosStackDeploymentService) InstallMonitoring(ctx context.Context, st
 // UninstallMonitoring uninstalls the monitoring for the given stack
 func (s *ThanosStackDeploymentService) UninstallMonitoring(ctx context.Context, stackId uuid.UUID) (*entities.Response, error) {
 	return s.integrationMgr.UninstallMonitoring(ctx, stackId)
+}
+
+// RegisterCandidate delegates candidate registration to the integrations layer
+func (s *ThanosStackDeploymentService) RegisterCandidate(ctx context.Context, stackId uuid.UUID, req dtos.RegisterCandidateRequest) (*entities.Response, error) {
+	return s.integrationMgr.RegisterCandidateForStack(ctx, stackId, req)
 }

--- a/pkg/services/thanos/service.go
+++ b/pkg/services/thanos/service.go
@@ -16,6 +16,7 @@ type ThanosStackDeploymentService struct {
 	integrationRepo IntegrationRepository
 	taskManager     TaskManager
 	integrationMgr  *integrations.IntegrationManager
+	logRepo         LogRepository
 }
 
 // taskManagerWrapper wraps TaskManager to match the interface expected by IntegrationManager
@@ -32,6 +33,7 @@ func NewThanosService(
 	stackRepo StackRepository,
 	integrationRepo IntegrationRepository,
 	taskManager TaskManager,
+	logRepo LogRepository,
 ) *ThanosStackDeploymentService {
 	taskManagerWrapper := &taskManagerWrapper{taskManager: taskManager}
 
@@ -42,6 +44,7 @@ func NewThanosService(
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
 		integrationMgr:  integrations.NewIntegrationManager(stackRepo, integrationRepo, taskManagerWrapper),
+		logRepo:         logRepo,
 	}
 
 	thanosDeploymentSrv.taskManager.Start()

--- a/pkg/services/thanos/service.go
+++ b/pkg/services/thanos/service.go
@@ -43,7 +43,7 @@ func NewThanosService(
 		stackRepo:       stackRepo,
 		integrationRepo: integrationRepo,
 		taskManager:     taskManager,
-		integrationMgr:  integrations.NewIntegrationManager(stackRepo, integrationRepo, taskManagerWrapper),
+        integrationMgr:  integrations.NewIntegrationManager(stackRepo, deploymentRepo, integrationRepo, taskManagerWrapper),
 		logRepo:         logRepo,
 	}
 

--- a/pkg/services/thanos/stack_lifecycle.go
+++ b/pkg/services/thanos/stack_lifecycle.go
@@ -167,6 +167,37 @@ func (s *ThanosStackDeploymentService) ResumeThanosStack(ctx context.Context, st
 			Data:    nil,
 		}, nil
 	}
+	// Create fresh deployment records for this resume
+	var stackConfig dtos.DeployThanosRequest
+	if err := json.Unmarshal(stack.Config, &stackConfig); err != nil {
+		logger.Error("failed to unmarshal stack config", zap.String("stackId", stackId.String()), zap.Error(err))
+		return &entities.Response{
+			Status:  http.StatusInternalServerError,
+			Message: "Internal server error",
+			Data:    nil,
+		}, err
+	}
+
+	deployments, err := getThanosStackDeployments(stackId, &stackConfig)
+	if err != nil {
+		logger.Error("failed to build deployments for resume", zap.String("stackId", stackId.String()), zap.Error(err))
+		return &entities.Response{
+			Status:  http.StatusInternalServerError,
+			Message: "Internal server error",
+			Data:    nil,
+		}, err
+	}
+
+	for _, d := range deployments {
+		if err := s.deploymentRepo.CreateDeployment(d); err != nil {
+			logger.Error("failed to create deployment record on resume", zap.String("stackId", stackId.String()), zap.Error(err))
+			return &entities.Response{
+				Status:  http.StatusInternalServerError,
+				Message: "Internal server error",
+				Data:    nil,
+			}, err
+		}
+	}
 
 	taskId := fmt.Sprintf("deploy-thanos-stack-%s", stackId.String())
 	s.taskManager.AddTask(taskId, func(ctx context.Context) {

--- a/pkg/services/thanos/termination.go
+++ b/pkg/services/thanos/termination.go
@@ -92,17 +92,6 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		return
 	}
 
-	err = s.deploymentRepo.UpdateStatusesByStackId(
-		stackId.String(),
-		entities.DeploymentStatusTerminated,
-	)
-	if err != nil {
-		logger.Error("failed to update deployments status to terminated",
-			zap.String("stackId", stackId.String()),
-			zap.Error(err))
-		return
-	}
-
 	// Update integrations status to terminated
 	err = s.integrationRepo.UpdateIntegrationsStatusByStackID(
 		stackId.String(),

--- a/pkg/services/thanos/termination.go
+++ b/pkg/services/thanos/termination.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/google/uuid"
 	"github.com/tokamak-network/trh-backend/internal/logger"
 	"github.com/tokamak-network/trh-backend/internal/utils"
 	"github.com/tokamak-network/trh-backend/pkg/api/dtos"
@@ -37,6 +38,31 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 
 	logPath := utils.GetLogPath(stack.ID, "destroy")
 
+	// Create a deployment record for termination
+	terminationDeploymentID := uuid.New()
+	terminationConfig, _ := json.Marshal(dtos.TerminateThanosRequest{
+		Network:            string(stack.Network),
+		AwsAccessKey:       stackConfig.AwsAccessKey,
+		AwsSecretAccessKey: stackConfig.AwsSecretAccessKey,
+		AwsRegion:          stackConfig.AwsRegion,
+		DeploymentPath:     stack.DeploymentPath,
+		LogPath:            logPath,
+	})
+	terminationDeployment := &entities.DeploymentEntity{
+		ID:      terminationDeploymentID,
+		StackID: &stack.ID,
+		Step:    "destroy-aws-infra",
+		Status:  entities.DeploymentStatusPending,
+		LogPath: logPath,
+		Config:  terminationConfig,
+	}
+	if err := s.deploymentRepo.CreateDeployment(terminationDeployment); err != nil {
+		logger.Error("failed to create termination deployment",
+			zap.String("stackId", stackId.String()),
+			zap.Error(err))
+		return
+	}
+
 	sdkClient, err := thanos.NewThanosSDKClient(
 		ctx,
 		logPath,
@@ -69,6 +95,13 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		return
 	}
 
+	// Start log ingestion for termination
+	ingestCtx, cancel := context.WithCancel(ctx)
+	go s.tailAndIngestDeploymentLogs(ingestCtx, stack.ID, terminationDeploymentID, logPath)
+
+	// Update deployment status to in-progress
+	_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusInProgress)
+
 	err = thanos.DestroyAWSInfrastructure(ctx, sdkClient)
 	if err != nil {
 		logger.Error("failed to destroy AWS infrastructure",
@@ -81,6 +114,8 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 				zap.String("stackId", stackId.String()),
 				zap.Error(updateErr))
 		}
+		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusFailed)
+		cancel()
 		return
 	}
 
@@ -89,6 +124,8 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		logger.Error("failed to update stacks status to terminated",
 			zap.String("stackId", stackId.String()),
 			zap.Error(err))
+		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusFailed)
+		cancel()
 		return
 	}
 
@@ -102,8 +139,13 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		logger.Error("failed to update integrations status to terminated",
 			zap.String("stackId", stackId.String()),
 			zap.Error(err))
+		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusFailed)
+		cancel()
 		return
 	}
+
+	_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusCompleted)
+	cancel()
 
 	logger.Info(
 		"AWS infrastructure destroyed successfully",

--- a/pkg/services/thanos/termination.go
+++ b/pkg/services/thanos/termination.go
@@ -52,7 +52,7 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		ID:      terminationDeploymentID,
 		StackID: &stack.ID,
 		Step:    "destroy-aws-infra",
-		Status:  entities.DeploymentStatusPending,
+		Status:  entities.DeploymentRunStatusNotStarted,
 		LogPath: logPath,
 		Config:  terminationConfig,
 	}
@@ -100,7 +100,7 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 	go s.tailAndIngestDeploymentLogs(ingestCtx, stack.ID, terminationDeploymentID, logPath)
 
 	// Update deployment status to in-progress
-	_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusInProgress)
+	_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentRunStatusInProgress)
 
 	err = thanos.DestroyAWSInfrastructure(ctx, sdkClient)
 	if err != nil {
@@ -114,7 +114,7 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 				zap.String("stackId", stackId.String()),
 				zap.Error(updateErr))
 		}
-		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusFailed)
+		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentRunStatusFailed)
 		cancel()
 		return
 	}
@@ -124,7 +124,7 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		logger.Error("failed to update stacks status to terminated",
 			zap.String("stackId", stackId.String()),
 			zap.Error(err))
-		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusFailed)
+		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentRunStatusFailed)
 		cancel()
 		return
 	}
@@ -139,12 +139,12 @@ func (s *ThanosStackDeploymentService) handleStackTermination(ctx context.Contex
 		logger.Error("failed to update integrations status to terminated",
 			zap.String("stackId", stackId.String()),
 			zap.Error(err))
-		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusFailed)
+		_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentRunStatusFailed)
 		cancel()
 		return
 	}
 
-	_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentStatusCompleted)
+	_ = s.deploymentRepo.UpdateDeploymentStatus(terminationDeploymentID.String(), entities.DeploymentRunStatusSuccess)
 	cancel()
 
 	logger.Info(

--- a/pkg/stacks/thanos/thanos_stack.go
+++ b/pkg/stacks/thanos/thanos_stack.go
@@ -192,6 +192,7 @@ func GetMonitoringConfig(
 			SmtpAuthPassword: alertManager.Email.SmtpAuthPassword,
 		},
 	}
+	// TODO: Add logging enabled flag in the future
 	return s.GetMonitoringConfig(ctx, password, thanosAlertManagerConfig, false)
 }
 


### PR DESCRIPTION
The summary of changes in this PR
- Store the logs of deployments into `logs` table of Postgres
- Create deployment record for plugin install/uninstallation as well
- Update the status enum of deployment

<img width="1612" height="795" alt="image" src="https://github.com/user-attachments/assets/85041695-1493-4fc7-9181-2b521685ec0d" />
