### PR TITLE
Fix: Updated chain name validation in ui

### DIFF
--- a/pkg/api/dtos/thanos.go
+++ b/pkg/api/dtos/thanos.go
@@ -70,7 +70,7 @@ func (request *DeployThanosRequest) Validate() error {
 	if !chainNameRegex.MatchString(request.ChainName) {
 		logger.Error("invalid chainName", zap.String("chainName", request.ChainName))
 		return errors.New(
-			"invalid chain name, chain name must contain only letters (a-z, A-Z), numbers (0-9), spaces. Special characters are not allowed",
+			"invalid chain name. It must start with a letter, contain only letters, numbers, and spaces, and be 1-14 characters long.",
 		)
 	}
 


### PR DESCRIPTION
This PR contains fix for chain name validation as in trh-sdk - [Link](https://github.com/tokamak-network/trh-sdk/blob/main/pkg/stacks/thanos/input.go#L28)


<img width="990" height="858" alt="image" src="https://github.com/user-attachments/assets/97efe3f5-f6cc-4bf7-a673-6a7eb5f40676" />
