### PR TITLE
fix: recover stuck integrations on server restart

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tokamak-network/trh-backend/pkg/api/routes"
 	"github.com/tokamak-network/trh-backend/pkg/api/servers"
 	"github.com/tokamak-network/trh-backend/pkg/infrastructure/postgres/connection"
+	"github.com/tokamak-network/trh-backend/pkg/workers"
 
 	"github.com/gin-contrib/cors"
 	"github.com/joho/godotenv"
@@ -56,6 +57,9 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to connect to postgres", zap.Error(err))
 	}
+
+	//Recovers integrations interrupted by server restart
+	workers.RecoverInterruptedIntegrations(postgresDB)
 
 	// programmatically set swagger info
 	docs.SwaggerInfo.Title = "TRH Backend"

--- a/pkg/infrastructure/postgres/repositories/integration.go
+++ b/pkg/infrastructure/postgres/repositories/integration.go
@@ -113,7 +113,23 @@ func (r *IntegrationRepository) GetInstalledIntegration(
 	integrationType string,
 ) (*entities.IntegrationEntity, error) {
 	var integration schemas.Integration
-	//this include Failed status to allow cleanup/uninstall of partial installations
+	if err := r.db.Where("stack_id = ?", stackId).Where("type", integrationType).Where("status IN (?)", []string{
+		string(entities.DeploymentStatusCompleted),
+	}).First(&integration).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil // No integration found
+		}
+		return nil, err
+	}
+	return ToIntegrationEntity(&integration), nil
+}
+
+// GetUninstallableIntegration returns integrations that can be uninstalled (Completed or Failed)
+func (r *IntegrationRepository) GetUninstallableIntegration(
+	stackId string,
+	integrationType string,
+) (*entities.IntegrationEntity, error) {
+	var integration schemas.Integration
 	if err := r.db.Where("stack_id = ?", stackId).Where("type", integrationType).Where("status IN (?)", []string{
 		string(entities.DeploymentStatusCompleted),
 		string(entities.DeploymentStatusFailed),
@@ -252,4 +268,9 @@ func ToIntegrationEntity(
 		LogPath: integration.LogPath,
 		Reason:  integration.Reason,
 	}
+}
+
+// DeleteIntegration removes an integration record from the database
+func (r *IntegrationRepository) DeleteIntegration(id string) error {
+	return r.db.Delete(&schemas.Integration{}, "id = ?", id).Error
 }

--- a/pkg/infrastructure/postgres/repositories/integration.go
+++ b/pkg/infrastructure/postgres/repositories/integration.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
 	"github.com/tokamak-network/trh-backend/pkg/infrastructure/postgres/schemas"
@@ -33,7 +34,15 @@ func (r *IntegrationRepository) UpdateIntegrationStatus(
 	id string,
 	status entities.DeploymentStatus,
 ) error {
-	return r.db.Model(&schemas.Integration{}).Where("id = ?", id).Update("status", status).Error
+	updates := map[string]interface{}{
+		"status": status,
+	}
+	//Sets started_at when transitioning to inprogress (for timeout tracking)
+	if status == entities.DeploymentStatusInProgress {
+		now := time.Now().UTC()
+		updates["started_at"] = &now
+	}
+	return r.db.Model(&schemas.Integration{}).Where("id = ?", id).Updates(updates).Error
 }
 
 func (r *IntegrationRepository) UpdateIntegrationStatusByStackID(
@@ -104,8 +113,10 @@ func (r *IntegrationRepository) GetInstalledIntegration(
 	integrationType string,
 ) (*entities.IntegrationEntity, error) {
 	var integration schemas.Integration
+	//this include Failed status to allow cleanup/uninstall of partial installations
 	if err := r.db.Where("stack_id = ?", stackId).Where("type", integrationType).Where("status IN (?)", []string{
 		string(entities.DeploymentStatusCompleted),
+		string(entities.DeploymentStatusFailed),
 	}).First(&integration).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // No integration found

--- a/pkg/infrastructure/postgres/schemas/integration.go
+++ b/pkg/infrastructure/postgres/schemas/integration.go
@@ -19,6 +19,7 @@ type Integration struct {
 	Config    datatypes.JSON            `gorm:"column:config;type:jsonb;default:null"`
 	Info      datatypes.JSON            `gorm:"column:info;type:jsonb;default:null"`
 	Reason    string                    `gorm:"column:reason;default:null"`
+	StartedAt *time.Time                `gorm:"column:started_at;default:null"`
 	CreatedAt time.Time                 `gorm:"autoCreateTime;column:created_at"`
 	UpdatedAt time.Time                 `gorm:"autoUpdateTime;column:updated_at"`
 	DeletedAt gorm.DeletedAt            `gorm:"column:deleted_at;default:null"`

--- a/pkg/services/thanos/integrations/block_explorer.go
+++ b/pkg/services/thanos/integrations/block_explorer.go
@@ -40,6 +40,8 @@ type BlockExplorerIntegration struct {
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -71,6 +73,8 @@ func NewBlockExplorerIntegration(
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -253,7 +257,7 @@ func (b *BlockExplorerIntegration) Uninstall(ctx context.Context, stackId string
 
 	logPath := utils.GetLogPath(stack.ID, "uninstall-block-explorer")
 
-	blockExplorerIntegration, _ := b.integrationRepo.GetInstalledIntegration(stack.ID.String(), enum.IntegrationTypeBlockExplorer.String())
+	blockExplorerIntegration, _ := b.integrationRepo.GetUninstallableIntegration(stack.ID.String(), enum.IntegrationTypeBlockExplorer.String())
 	if blockExplorerIntegration == nil {
 		return &entities.Response{
 			Status:  http.StatusNotFound,
@@ -334,9 +338,21 @@ func (b *BlockExplorerIntegration) installTask(ctx context.Context, newIntegrati
 	if err != nil {
 		logger.Error("failed to install block explorer", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(err))
 
-		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
-			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+		// Auto cleanup: attempt to remove any partially created resources
+		logger.Info("attempting automatic cleanup of failed block explorer installation", zap.String("integrationId", newIntegrationID.String()))
+		if cleanupErr := thanos.UninstallBlockExplorer(taskCtx, sdkClient); cleanupErr != nil {
+			logger.Warn("automatic cleanup failed", zap.String("integrationId", newIntegrationID.String()), zap.Error(cleanupErr))
+			reason := fmt.Sprintf("installation failed: %s; cleanup failed: %s", err.Error(), cleanupErr.Error())
+			if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, reason); updateErr != nil {
+				logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBlockExplorer.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+			}
+		} else {
+			logger.Info("automatic cleanup successful, removing integration record", zap.String("integrationId", newIntegrationID.String()))
+			if deleteErr := b.integrationRepo.DeleteIntegration(newIntegrationID.String()); deleteErr != nil {
+				logger.Error("failed to delete integration after cleanup", zap.String("integrationId", newIntegrationID.String()), zap.Error(deleteErr))
+			}
 		}
+
 		deploymentStatus := entities.DeploymentRunStatusFailed
 		if utils.IsContextCanceled(err) {
 			deploymentStatus = entities.DeploymentRunStatusStopped

--- a/pkg/services/thanos/integrations/bridge.go
+++ b/pkg/services/thanos/integrations/bridge.go
@@ -40,6 +40,8 @@ type BridgeIntegration struct {
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -71,6 +73,8 @@ func NewBridgeIntegration(
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -193,7 +197,7 @@ func (b *BridgeIntegration) Uninstall(ctx context.Context, stackId string) (*ent
 
 	logPath := utils.GetLogPath(stack.ID, "uninstall-bridge")
 
-	bridgeIntegration, _ := b.integrationRepo.GetInstalledIntegration(stack.ID.String(), enum.IntegrationTypeBridge.String())
+	bridgeIntegration, _ := b.integrationRepo.GetUninstallableIntegration(stack.ID.String(), enum.IntegrationTypeBridge.String())
 	if bridgeIntegration == nil {
 		return &entities.Response{
 			Status:  http.StatusNotFound,
@@ -276,9 +280,23 @@ func (b *BridgeIntegration) installTask(ctx context.Context, newIntegrationID uu
 	if err != nil {
 		logger.Error("failed to install bridge", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(err))
 
-		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
-			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+		// Auto cleanup: attempt to remove any partially created resources
+		logger.Info("attempting automatic cleanup of failed bridge installation", zap.String("integrationId", newIntegrationID.String()))
+		if cleanupErr := thanos.UninstallBridge(taskCtx, sdkClient); cleanupErr != nil {
+			logger.Warn("automatic cleanup failed", zap.String("integrationId", newIntegrationID.String()), zap.Error(cleanupErr))
+			// Cleanup failed - mark as Failed so user can manually uninstall
+			reason := fmt.Sprintf("installation failed: %s; cleanup failed: %s", err.Error(), cleanupErr.Error())
+			if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, reason); updateErr != nil {
+				logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeBridge.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+			}
+		} else {
+			logger.Info("automatic cleanup successful, removing integration record", zap.String("integrationId", newIntegrationID.String()))
+			// Cleanup succeeded - delete the integration record
+			if deleteErr := b.integrationRepo.DeleteIntegration(newIntegrationID.String()); deleteErr != nil {
+				logger.Error("failed to delete integration after cleanup", zap.String("integrationId", newIntegrationID.String()), zap.Error(deleteErr))
+			}
 		}
+
 		deploymentStatus := entities.DeploymentRunStatusFailed
 		if utils.IsContextCanceled(err) {
 			deploymentStatus = entities.DeploymentRunStatusStopped

--- a/pkg/services/thanos/integrations/cross_trade.go
+++ b/pkg/services/thanos/integrations/cross_trade.go
@@ -40,6 +40,8 @@ type CrossTradeBridgeIntegration struct {
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationByStatus(
@@ -79,6 +81,8 @@ func NewCrossTradeBridgeIntegration(
 			integrationType string,
 			status entities.DeploymentStatus,
 		) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -355,10 +359,23 @@ func (b *CrossTradeBridgeIntegration) installTask(ctx context.Context, stack *en
 	}
 	output, err := thanos.InstallCrossTradeBridge(ctx, sdkClient, &request)
 	if err != nil {
-		logger.Error("failed to install cross trade", zap.String("plugin", integrationType), zap.Error(err))
-		if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(pendingIntegration.ID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
-			logger.Error("failed to update integration status", zap.String("plugin", integrationType), zap.Error(updateErr), zap.String("integrationId", pendingIntegration.ID.String()))
+		logger.Error("failed to install cross trade", zap.String("plugin", enum.IntegrationTypeCrossTrade.String()), zap.Error(err))
+
+		// Auto cleanup: attempt to remove any partially created resources
+		logger.Info("attempting automatic cleanup of failed cross trade installation", zap.String("integrationId", pendingIntegration.ID.String()))
+		if cleanupErr := thanos.UninstallCrossTradeBridge(ctx, sdkClient, string(request.Mode)); cleanupErr != nil {
+			logger.Warn("automatic cleanup failed", zap.String("integrationId", pendingIntegration.ID.String()), zap.Error(cleanupErr))
+			reason := fmt.Sprintf("installation failed: %s; cleanup failed: %s", err.Error(), cleanupErr.Error())
+			if updateErr := b.integrationRepo.UpdateIntegrationStatusWithReason(pendingIntegration.ID.String(), entities.DeploymentStatusFailed, reason); updateErr != nil {
+				logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeCrossTrade.String()), zap.Error(updateErr), zap.String("integrationId", pendingIntegration.ID.String()))
+			}
+		} else {
+			logger.Info("automatic cleanup successful, removing integration record", zap.String("integrationId", pendingIntegration.ID.String()))
+			if deleteErr := b.integrationRepo.DeleteIntegration(pendingIntegration.ID.String()); deleteErr != nil {
+				logger.Error("failed to delete integration after cleanup", zap.String("integrationId", pendingIntegration.ID.String()), zap.Error(deleteErr))
+			}
 		}
+
 		deploymentStatus := entities.DeploymentRunStatusFailed
 		if utils.IsContextCanceled(err) {
 			deploymentStatus = entities.DeploymentRunStatusStopped

--- a/pkg/services/thanos/integrations/interfaces.go
+++ b/pkg/services/thanos/integrations/interfaces.go
@@ -42,6 +42,8 @@ func NewIntegrationManager(
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationByStatus(stackId string, integrationType string, status entities.DeploymentStatus) (*entities.IntegrationEntity, error)

--- a/pkg/services/thanos/integrations/monitoring.go
+++ b/pkg/services/thanos/integrations/monitoring.go
@@ -40,6 +40,8 @@ type MonitoringIntegration struct {
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -71,6 +73,8 @@ func NewMonitoringIntegration(
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -234,7 +238,7 @@ func (m *MonitoringIntegration) Uninstall(ctx context.Context, stackId uuid.UUID
 
 	logPath := utils.GetLogPath(stack.ID, "uninstall-monitoring")
 
-	monitoringIntegration, _ := m.integrationRepo.GetInstalledIntegration(stack.ID.String(), enum.IntegrationTypeMonitoring.String())
+	monitoringIntegration, _ := m.integrationRepo.GetUninstallableIntegration(stack.ID.String(), enum.IntegrationTypeMonitoring.String())
 	if monitoringIntegration == nil {
 		return &entities.Response{
 			Status:  http.StatusNotFound,
@@ -335,9 +339,21 @@ func (m *MonitoringIntegration) installTask(ctx context.Context, newIntegrationI
 	if err != nil {
 		logger.Error("failed to install monitoring", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(err))
 
-		if updateErr := m.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
-			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+		// Auto cleanup: attempt to remove any partially created resources
+		logger.Info("attempting automatic cleanup of failed monitoring installation", zap.String("integrationId", newIntegrationID.String()))
+		if cleanupErr := thanos.UninstallMonitoring(taskCtx, sdkClient); cleanupErr != nil {
+			logger.Warn("automatic cleanup failed", zap.String("integrationId", newIntegrationID.String()), zap.Error(cleanupErr))
+			reason := fmt.Sprintf("installation failed: %s; cleanup failed: %s", err.Error(), cleanupErr.Error())
+			if updateErr := m.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, reason); updateErr != nil {
+				logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeMonitoring.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+			}
+		} else {
+			logger.Info("automatic cleanup successful, removing integration record", zap.String("integrationId", newIntegrationID.String()))
+			if deleteErr := m.integrationRepo.DeleteIntegration(newIntegrationID.String()); deleteErr != nil {
+				logger.Error("failed to delete integration after cleanup", zap.String("integrationId", newIntegrationID.String()), zap.Error(deleteErr))
+			}
 		}
+
 		deploymentStatus := entities.DeploymentRunStatusFailed
 		if utils.IsContextCanceled(err) {
 			deploymentStatus = entities.DeploymentRunStatusStopped

--- a/pkg/services/thanos/integrations/register_candidate.go
+++ b/pkg/services/thanos/integrations/register_candidate.go
@@ -39,6 +39,8 @@ type RegisterCandidateIntegration struct {
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
 	}
@@ -68,6 +70,8 @@ func NewRegisterCandidateIntegration(
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
 	},

--- a/pkg/services/thanos/integrations/register_medata_dao.go
+++ b/pkg/services/thanos/integrations/register_medata_dao.go
@@ -39,6 +39,8 @@ type RegisterMetadataDAOIntegration struct {
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 	}
 	logRepo interface {
 		CreateLog(log *entities.LogEntity) error
@@ -64,6 +66,8 @@ func NewRegisterMetadataDAOIntegration(
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 	},
 	logRepo interface {
 		CreateLog(log *entities.LogEntity) error

--- a/pkg/services/thanos/integrations/uptime_service.go
+++ b/pkg/services/thanos/integrations/uptime_service.go
@@ -40,6 +40,8 @@ type UptimeServiceIntegration struct {
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -71,6 +73,8 @@ func NewUptimeServiceIntegration(
 		UpdateIntegrationStatus(id string, status entities.DeploymentStatus) error
 		UpdateIntegrationStatusWithReason(id string, status entities.DeploymentStatus, reason string) error
 		GetInstalledIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		GetUninstallableIntegration(stackId, integrationType string) (*entities.IntegrationEntity, error)
+		DeleteIntegration(id string) error
 		UpdateConfig(id string, config json.RawMessage) error
 		UpdateMetadataAfterInstalled(id string, metadata entities.IntegrationInfo) error
 		GetIntegrationById(id string) (*entities.IntegrationEntity, error)
@@ -215,7 +219,7 @@ func (u *UptimeServiceIntegration) Uninstall(ctx context.Context, stackId string
 
 	logPath := utils.GetLogPath(stack.ID, "uninstall-system-pulse")
 
-	uptimeServiceIntegration, err := u.integrationRepo.GetInstalledIntegration(stack.ID.String(), enum.IntegrationTypeUptimeService.String())
+	uptimeServiceIntegration, err := u.integrationRepo.GetUninstallableIntegration(stack.ID.String(), enum.IntegrationTypeUptimeService.String())
 	if err != nil {
 		logger.Error("failed to get integration", zap.String("plugin", enum.IntegrationTypeUptimeService.String()), zap.Error(err))
 		return &entities.Response{
@@ -308,8 +312,19 @@ func (u *UptimeServiceIntegration) installTask(ctx context.Context, newIntegrati
 	if err != nil {
 		logger.Error("failed to install uptime service", zap.String("plugin", enum.IntegrationTypeUptimeService.String()), zap.Error(err))
 
-		if updateErr := u.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, err.Error()); updateErr != nil {
-			logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeUptimeService.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+		// Auto cleanup: attempt to remove any partially created resources
+		logger.Info("attempting automatic cleanup of failed uptime service installation", zap.String("integrationId", newIntegrationID.String()))
+		if cleanupErr := thanos.UninstallUptimeService(taskCtx, sdkClient); cleanupErr != nil {
+			logger.Warn("automatic cleanup failed", zap.String("integrationId", newIntegrationID.String()), zap.Error(cleanupErr))
+			reason := fmt.Sprintf("installation failed: %s; cleanup failed: %s", err.Error(), cleanupErr.Error())
+			if updateErr := u.integrationRepo.UpdateIntegrationStatusWithReason(newIntegrationID.String(), entities.DeploymentStatusFailed, reason); updateErr != nil {
+				logger.Error("failed to update integration status", zap.String("plugin", enum.IntegrationTypeUptimeService.String()), zap.Error(updateErr), zap.String("integrationId", newIntegrationID.String()))
+			}
+		} else {
+			logger.Info("automatic cleanup successful, removing integration record", zap.String("integrationId", newIntegrationID.String()))
+			if deleteErr := u.integrationRepo.DeleteIntegration(newIntegrationID.String()); deleteErr != nil {
+				logger.Error("failed to delete integration after cleanup", zap.String("integrationId", newIntegrationID.String()), zap.Error(deleteErr))
+			}
 		}
 
 		deploymentStatus := entities.DeploymentRunStatusFailed

--- a/pkg/services/thanos/interfaces.go
+++ b/pkg/services/thanos/interfaces.go
@@ -62,6 +62,11 @@ type IntegrationRepository interface {
 		stackId string,
 		integrationType string,
 	) (*entities.IntegrationEntity, error)
+	GetUninstallableIntegration(
+		stackId string,
+		integrationType string,
+	) (*entities.IntegrationEntity, error)
+	DeleteIntegration(id string) error
 	GetActiveIntegrations(
 		stackId string,
 		integrationType string,

--- a/pkg/workers/recovery.go
+++ b/pkg/workers/recovery.go
@@ -22,12 +22,11 @@ const recoveryTimeout = 5 * time.Minute
 //uninstaller defines the signature for integration uninstall functions
 type uninstaller func(context.Context, *thanosSDK.ThanosStack) error
 
-// this maps integration types to their cleanup fuunctions
+// this maps integration types to their cleanup functions
 var uninstallers = map[enum.IntegrationType]uninstaller{
 	enum.IntegrationTypeBridge:        thanos.UninstallBridge,
 	enum.IntegrationTypeBlockExplorer: thanos.UninstallBlockExplorer,
 	enum.IntegrationTypeMonitoring:    thanos.UninstallMonitoring,
-	enum.IntegrationTypeCrossTrade:    thanos.UninstallCrossTradeBridge,
 	enum.IntegrationTypeUptimeService: thanos.UninstallUptimeService,
 }
 
@@ -97,8 +96,9 @@ func recoverIntegration(db *gorm.DB, integration *schemas.Integration) {
 }
 
 func cleanupIntegrationResources(integration *schemas.Integration) error {
-	uninstall, ok := uninstallers[enum.IntegrationType(integration.Type)]
-	if !ok {
+	intType := enum.IntegrationType(integration.Type)
+	uninstall, ok := uninstallers[intType]
+	if !ok && intType != enum.IntegrationTypeCrossTrade {
 		return nil
 	}
 
@@ -139,6 +139,14 @@ func cleanupIntegrationResources(integration *schemas.Integration) error {
 	)
 	if err != nil {
 		return err
+	}
+
+	if intType == enum.IntegrationTypeCrossTrade {
+		var installReq dtos.InstallCrossChainBridgeRequest
+		if err := json.Unmarshal(integration.Config, &installReq); err != nil {
+			return err
+		}
+		return thanos.UninstallCrossTradeBridge(ctx, client, string(installReq.Mode))
 	}
 
 	return uninstall(ctx, client)

--- a/pkg/workers/recovery.go
+++ b/pkg/workers/recovery.go
@@ -1,0 +1,28 @@
+package workers
+
+import (
+	"github.com/tokamak-network/trh-backend/internal/logger"
+	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
+	"github.com/tokamak-network/trh-backend/pkg/infrastructure/postgres/schemas"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// RecoverInterruptedIntegrations marks stale inprogress integrations as failed on startup...
+func RecoverInterruptedIntegrations(db *gorm.DB) {
+	result := db.Model(&schemas.Integration{}).
+		Where("status = ?", entities.DeploymentStatusInProgress).
+		Updates(map[string]interface{}{
+			"status": entities.DeploymentStatusFailed,
+			"reason": "Installation interrupted by server restart",
+		})
+
+	if result.Error != nil {
+		logger.Error("failed to recover interrupted integrations", zap.Error(result.Error))
+		return
+	}
+
+	if result.RowsAffected > 0 {
+		logger.Warn("recovered interrupted integrations", zap.Int64("count", result.RowsAffected))
+	}
+}

--- a/pkg/workers/recovery.go
+++ b/pkg/workers/recovery.go
@@ -1,28 +1,145 @@
 package workers
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
 	"github.com/tokamak-network/trh-backend/internal/logger"
+	"github.com/tokamak-network/trh-backend/pkg/api/dtos"
 	"github.com/tokamak-network/trh-backend/pkg/domain/entities"
+	"github.com/tokamak-network/trh-backend/pkg/enum"
 	"github.com/tokamak-network/trh-backend/pkg/infrastructure/postgres/schemas"
+	"github.com/tokamak-network/trh-backend/pkg/stacks/thanos"
+	thanosSDK "github.com/tokamak-network/trh-sdk/pkg/stacks/thanos"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
-// RecoverInterruptedIntegrations marks stale inprogress integrations as failed on startup...
-func RecoverInterruptedIntegrations(db *gorm.DB) {
-	result := db.Model(&schemas.Integration{}).
-		Where("status = ?", entities.DeploymentStatusInProgress).
-		Updates(map[string]interface{}{
-			"status": entities.DeploymentStatusFailed,
-			"reason": "Installation interrupted by server restart",
-		})
+const recoveryTimeout = 5 * time.Minute
 
-	if result.Error != nil {
-		logger.Error("failed to recover interrupted integrations", zap.Error(result.Error))
+//uninstaller defines the signature for integration uninstall functions
+type uninstaller func(context.Context, *thanosSDK.ThanosStack) error
+
+// this maps integration types to their cleanup fuunctions
+var uninstallers = map[enum.IntegrationType]uninstaller{
+	enum.IntegrationTypeBridge:        thanos.UninstallBridge,
+	enum.IntegrationTypeBlockExplorer: thanos.UninstallBlockExplorer,
+	enum.IntegrationTypeMonitoring:    thanos.UninstallMonitoring,
+	enum.IntegrationTypeCrossTrade:    thanos.UninstallCrossTradeBridge,
+	enum.IntegrationTypeUptimeService: thanos.UninstallUptimeService,
+}
+
+//so recoverInterruptedIntegrations finds integrations stuck in inprogress state
+//from server crash and cleansup their resources before marking them failed
+func RecoverInterruptedIntegrations(db *gorm.DB) {
+	var integrations []schemas.Integration
+
+	err := db.Preload("Stack").
+		Where("status = ?", entities.DeploymentStatusInProgress).
+		Find(&integrations).Error
+	if err != nil {
+		logger.Error("failed to query interrupted integrations", zap.Error(err))
 		return
 	}
 
-	if result.RowsAffected > 0 {
-		logger.Warn("recovered interrupted integrations", zap.Int64("count", result.RowsAffected))
+	if len(integrations) == 0 {
+		return
 	}
+
+	logger.Warn("recovering interrupted integrations", zap.Int("count", len(integrations)))
+
+	for i := range integrations {
+		recoverIntegration(db, &integrations[i])
+	}
+
+	logger.Info("recovery complete")
+}
+
+func recoverIntegration(db *gorm.DB, integration *schemas.Integration) {
+	id := integration.ID.String()
+	typ := integration.Type
+
+	logger.Info("recovering integration", zap.String("id", id), zap.String("type", typ))
+
+	// tur cleanup if we have stack info
+	cleanupSuccess := false
+	if integration.Stack != nil {
+		if err := cleanupIntegrationResources(integration); err != nil {
+			logger.Warn("cleanup failed", zap.String("id", id), zap.Error(err))
+		} else {
+			cleanupSuccess = true
+			logger.Info("cleanup successful", zap.String("id", id))
+		}
+	}
+
+	if cleanupSuccess {
+		// changed this to delete from db after successful cleanup instead of failed shoing on UI before
+		err := db.Delete(&schemas.Integration{}, "id = ?", integration.ID).Error
+		if err != nil {
+			logger.Error("failed to delete integration", zap.String("id", id), zap.Error(err))
+		} else {
+			logger.Info("deleted interrupted integration", zap.String("id", id))
+		}
+	} else {
+		// mark failed if cleanup didnt run or failed so user can retry manually
+		err := db.Model(&schemas.Integration{}).
+			Where("id = ?", id).
+			Updates(map[string]interface{}{
+				"status": entities.DeploymentStatusFailed,
+				"reason": "interrupted by server restart",
+			}).Error
+		if err != nil {
+			logger.Error("failed to update status", zap.String("id", id), zap.Error(err))
+		}
+	}
+}
+
+func cleanupIntegrationResources(integration *schemas.Integration) error {
+	uninstall, ok := uninstallers[enum.IntegrationType(integration.Type)]
+	if !ok {
+		return nil
+	}
+
+	stack := integration.Stack
+
+	// checks if deployment path exists before attempting cleanup
+	if stack.DeploymentPath == "" {
+		logger.Info("skipping cleanup: no deployment path")
+		return nil
+	}
+	if _, err := os.Stat(stack.DeploymentPath); os.IsNotExist(err) {
+		logger.Info("skipping cleanup: deployment path does not exist", zap.String("path", stack.DeploymentPath))
+		return nil
+	}
+
+	var cfg dtos.DeployThanosRequest
+	if err := json.Unmarshal(stack.Config, &cfg); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), recoveryTimeout)
+	defer cancel()
+
+	logger.Info("attempting cleanup", zap.String("type", integration.Type), zap.String("path", stack.DeploymentPath))
+
+	// using deployment path for log file during cleanup
+	logPath := stack.DeploymentPath + "/recovery.log"
+
+	client, err := thanos.NewThanosSDKClient(
+		ctx,
+		logPath,
+		string(stack.Network),
+		stack.DeploymentPath,
+		false,
+		cfg.AwsAccessKey,
+		cfg.AwsSecretAccessKey,
+		cfg.AwsRegion,
+	)
+	if err != nil {
+		return err
+	}
+
+	return uninstall(ctx, client)
 }


### PR DESCRIPTION
**If the server crashes or restarts while a plugin is installing, the integration stays stuck in "InProgress" forever. Users can't do anything with it - can't reinstall, can't uninstall, it's just stuck there.**

**Fix**:
Added a recovery check that runs when the server starts up. It finds any integrations stuck in "InProgress" and marks them as "Failed" so users can see what happened and clean them up.

**Changes**:
  - pkg/workers/recovery.go - new file that checks for stuck integrations on startup and marks them as failed                                                                      
  - main.go - calls the recovery function when server starts                                                                                                                       
  - integration.go (repository) - added started_at timestamp tracking, and allowed uninstall to work on Failed integrations (not just Completed ones)                              
  - integration.go (schema) - added StartedAt field to track when installation began
  
   **Testin**:
  1. Installed System Pulse plugin                                                                                                                                                 
  2. Killed the server while it was installing                                                                                                                                     
  3. Restarted server - integration showed "Failed" with reason "Installation interrupted by server restart"                                                                       
  4. Clicked uninstall - worked and cleaned up resources                                                                                                                           
  5. Verified with kubectl/helm - no leftover namespaces or releases
  
  
  After server restart, integration shows "Failed" status
<img width="449" height="267" alt="1" src="https://github.com/user-attachments/assets/e2d68494-40d6-4132-a50e-fb3dbb218c12" />
Clicking uninstall on failed integration work
<img width="434" height="277" alt="2" src="https://github.com/user-attachments/assets/13f6a9bb-0d90-4231-9cff-5e848091b315" />
 Logs showing uninstall task running and cleanup
<img width="1454" height="608" alt="3" src="https://github.com/user-attachments/assets/07f0772f-c09f-495e-8585-2fc8c5ed7a51" />
No integration namespaces left (cleanup verified)
<img width="745" height="148" alt="Screenshot 2025-12-26 at 4 44 33 AM" src="https://github.com/user-attachments/assets/d4abfcf7-ca70-476f-ae96-3ca0e24caeea" />
No integration helm releases left (cleanup verified)
<img width="1414" height="124" alt="Screenshot 2025-12-26 at 4 46 12 AM" src="https://github.com/user-attachments/assets/d6093919-3428-4ad2-ac5b-bba168dac9d0" />
Shows integration status changed to Terminated
<img width="528" height="295" alt="Screenshot 2025-12-26 at 4 48 51 AM" src="https://github.com/user-attachments/assets/32a66056-5d16-473e-ab70-5110d74aec99" />
UI confirms uninstall completed successfully
<img width="1025" height="63" alt="Screenshot 2025-12-26 at 4 30 26 AM" src="https://github.com/user-attachments/assets/58253bca-8dd0-4157-9b18-069f7c35cd3f" />
